### PR TITLE
Add assertion attributes to child object on profile (passport-saml#543)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,7 +24,11 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm ci
-      - run: npm --depth 9999 update
+      - run: npm update
+      # Remove the node_modules and re-install with updated package-lock.json
+      # because npm update command breaks some of the npm-cli packages
+      - run: rm -rf node_modules
+      - run: npm ci
       - run: npm test
         env:
           CI: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,11 +24,7 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm ci
-      - run: npm update
-      # Remove the node_modules and re-install with updated package-lock.json
-      # because npm update command breaks some of the npm-cli packages
-      - run: rm -rf node_modules
-      - run: npm ci
+      - run: npm --depth 9999 update
       - run: npm test
         env:
           CI: true

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -1167,18 +1167,33 @@ class SAML {
       };
 
       if (attributes) {
+        const profileAttributes: Record<string, unknown> = {};
+
         attributes.forEach((attribute) => {
           if (!Object.prototype.hasOwnProperty.call(attribute, "AttributeValue")) {
             // if attributes has no AttributeValue child, continue
             return;
           }
-          const value = attribute.AttributeValue;
-          if (value.length === 1) {
-            profile[attribute.$.Name] = attrValueMapper(value[0]);
-          } else {
-            profile[attribute.$.Name] = value.map(attrValueMapper);
+
+          const name = attribute.$.Name;
+          const value =
+            attribute.AttributeValue.length === 1
+              ? attrValueMapper(attribute.AttributeValue[0])
+              : attribute.AttributeValue.map(attrValueMapper);
+
+          profileAttributes[name] = value;
+
+          // If any property is already present in profile and is also present
+          // in attributes, then skip the one from attributes. Handle this
+          // conflict gracefully without returning any error
+          if (Object.prototype.hasOwnProperty.call(profile, name)) {
+            return;
           }
+
+          profile[name] = value;
         });
+
+        profile.attributes = profileAttributes;
       }
     }
 

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -1895,10 +1895,13 @@ describe("node-saml /", function () {
     });
   });
   describe("validatePostRequest()", function () {
+    const signingKey: any = fs.readFileSync(__dirname + "/static/key.pem", "ascii");
+    const signingCert: any = fs.readFileSync(__dirname + "/static/cert.pem", "ascii");
     let samlObj: SAML;
+
     beforeEach(function () {
       samlObj = new SAML({
-        cert: fs.readFileSync(__dirname + "/static/cert.pem", "ascii"),
+        cert: signingCert,
       });
     });
 
@@ -1972,7 +1975,35 @@ describe("node-saml /", function () {
         sessionIndex: "1",
       });
     });
+
+    it("check conflicting profile fields with data from attributes", async () => {
+      const testSAMLObj = new SAML({ cert: signingCert, issuer: "okta" });
+      const xml =
+        '<Response xmlns="urn:oasis:names:tc:SAML:2.0:protocol" ID="response0">' +
+        '<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0">' +
+        "<saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>" +
+        "<saml2:AttributeStatement>" +
+        '<saml2:Attribute Name="attributeName" ' +
+        'NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">' +
+        '<saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" ' +
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+        'xsi:type="xs:string"/>' +
+        "</saml2:Attribute>" +
+        '<saml2:Attribute Name="issuer" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">' +
+        '<saml2:AttributeValue xsi:type="xs:string">test</saml2:AttributeValue>' +
+        "</saml2:Attribute>" +
+        "</saml2:AttributeStatement>" +
+        "</saml2:Assertion>" +
+        "</Response>";
+      const signedXml = signXmlResponse(xml, { privateKey: signingKey });
+      const { profile } = await testSAMLObj.validatePostResponseAsync({
+        SAMLResponse: Buffer.from(signedXml).toString("base64"),
+      });
+
+      should(profile!.issuer).not.be.equal("test");
+    });
   });
+
   it("validatePostRequest errors for encrypted nameID with wrong decryptionPvk", async () => {
     const samlObj = new SAML({
       cert: fs.readFileSync(__dirname + "/static/cert.pem", "ascii"),


### PR DESCRIPTION
This attributes are also mounted to profile directly in a non conflicting way.

Duplicate PR of: https://github.com/node-saml/passport-saml/pull/593