### PR TITLE
Fix workflow for Node 16.x

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,8 +23,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm test
+      - run: npm update
       - run: npm ci
-      - run: npm --depth 9999 update
       - run: npm test
         env:
           CI: true


### PR DESCRIPTION
This addresses the build error that is generated with node 16.x and Node 7.x after running `npm update`.

```
node:internal/modules/cjs/loader:944
  throw err;
  ^

Error: Cannot find module 'npmlog'
Require stack:
- /home/runner/work/node-saml/node-saml/node_modules/npm/bin/npm-cli.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:941:15)
    at Function.Module._load (node:internal/modules/cjs/loader:774:27)
    at Module.require (node:internal/modules/cjs/loader:1013:19)
    at require (node:internal/modules/cjs/helpers:93:18)
    at /home/runner/work/node-saml/node-saml/node_modules/npm/bin/npm-cli.js:22:13
    at Object.<anonymous> (/home/runner/work/node-saml/node-saml/node_modules/npm/bin/npm-cli.js:155:3)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/runner/work/node-saml/node-saml/node_modules/npm/bin/npm-cli.js'
  ]
}
```

