### PR TITLE
Support importing to `passport-saml` project

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import type { CacheItem, CacheProvider } from "./inmemory-cache-provider";
 import { SAML } from "./saml";
+import { MandatorySamlOptions, Profile, SamlConfig, SamlOptions } from "./types";
 
-export { SAML, CacheItem, CacheProvider };
+export { SAML, CacheItem, CacheProvider, SamlOptions, MandatorySamlOptions, Profile, SamlConfig };


### PR DESCRIPTION
There are some changes needed to support this project being imported to the [passport-saml](https://github.com/node-saml/passport-saml) project. When The corresponding [PR](https://github.com/node-saml/passport-saml/pull/612) against [passport-saml](https://github.com/node-saml/passport-saml) is ready to land, this PR can land and then be released as a 4.0.0 version, regardless if there are breaking changes or not.

This is needed so that there is no NPM conflict with the current 3.x series of releases which takes a different approach to splitting the SAML stuff from the Passport stuff. Thus, this isn't an internally breaking change, but rather a breaking change with the existing NPM package which is currently based off a different GitHub repo.