### PR TITLE
Feature: add facility in config to add `<Extensions>` element in SAML request

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ const saml = new SAML(options);
 - `logoutCallbackUrl`: The value with which to populate the `Location` attribute in the `SingleLogoutService` elements in the generated service provider metadata.
 
 - **SAML Extensions**
-- `samlExtensions`: Optional, The SAML extension provides a more flexible structure for expressing which combination of Attributes are requested by service providers in comparison to the existing mechanisms, [More about extensions](https://docs.oasis-open.org/security/saml-protoc-req-attr-req/v1.0/saml-protoc-req-attr-req-v1.0.html). It accepts fully customize [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) type. There are many possible values for the `samlExtensions` element. You can use [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) to request attributes/data as per your need in SAML Request.
+- `samlExtensions`: Optional, The SAML extension provides a more flexible structure for expressing which combination of Attributes are requested by service providers in comparison to the existing mechanisms, [More about extensions](https://docs.oasis-open.org/security/saml-protoc-req-attr-req/v1.0/saml-protoc-req-attr-req-v1.0.html). There are many possible values for the `samlExtensions` element. It accepts fully customize [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) type.
 
 ```javascript
 // Example

--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ const saml = new SAML(options);
 - `additionalLogoutParams`: dictionary of additional query params to add to 'logout' requests
 - `logoutCallbackUrl`: The value with which to populate the `Location` attribute in the `SingleLogoutService` elements in the generated service provider metadata.
 
+- **SAML Extensions**
+- `samlExtensions`: Optional, The SAML extension provides a more flexible structure for expressing which combination of Attributes are requested by service providers in comparison to the existing mechanisms, [More about extensions](https://docs.oasis-open.org/security/saml-protoc-req-attr-req/v1.0/saml-protoc-req-attr-req-v1.0.html). It accepts fully customize [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) type. There are many possible values for the `samlExtensions` element. You can use [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) to request attributes/data as per your need in SAML Request.
+
+```javascript
+// Example
+samlExtensions: {
+  "md:RequestedAttribute": {
+    "@isRequired": "true",
+    "@Name": "Lastname",
+  },
+  vetuma: {
+    "@xmlns": "urn:vetuma:SAML:2.0:extensions",
+    LG: {
+      "#text": "sv",
+    },
+  },
+},
+```
+
 ### generateServiceProviderMetadata( decryptionCert, signingCert )
 
 As a convenience, the strategy object exposes a `generateServiceProviderMetadata` method which will generate a service provider metadata document suitable for supplying to an identity provider. This method will only work on strategies which are configured with a `callbackUrl` (since the relative path for the callback is not sufficient information to generate a complete metadata document).

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -352,6 +352,10 @@ class SAML {
       request["samlp:AuthnRequest"]["samlp:Scoping"] = scoping;
     }
 
+    if (this.options.samlExtensions != null) {
+      request["samlp:AuthnRequest"]["samlp:Extensions"] = this.options.samlExtensions;
+    }
+
     let stringRequest = buildXmlBuilderObject(request, false);
     // TODO: maybe we should always sign here
     if (isHttpPostBinding && isValidSamlSigningOptions(this.options)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,7 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
 
   // extras
   disableRequestAcsUrl: boolean;
+  samlExtensions?: any;
 }
 
 export interface StrategyOptions {

--- a/test/samlRequest.spec.ts
+++ b/test/samlRequest.spec.ts
@@ -1,0 +1,119 @@
+import { SAML } from "../src/saml";
+import { FAKE_CERT, SamlCheck } from "./types";
+import * as zlib from "zlib";
+import * as should from "should";
+import { parseString } from "xml2js";
+
+const capturedSamlRequestChecks: SamlCheck[] = [
+  {
+    name: "Config with Extensions",
+    config: {
+      entryPoint: "https://wwwexampleIdp.com/saml",
+      cert: FAKE_CERT,
+      samlExtensions: {
+        "md:RequestedAttribute": {
+          "@isRequired": "true",
+          "@Name": "Lastname",
+        },
+        vetuma: {
+          "@xmlns": "urn:vetuma:SAML:2.0:extensions",
+          LG: {
+            "#text": "sv",
+          },
+        },
+      },
+    },
+    result: {
+      "samlp:AuthnRequest": {
+        $: {
+          "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+          Version: "2.0",
+          ProtocolBinding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+          AssertionConsumerServiceURL: "http://localhost/saml/consume",
+          Destination: "https://wwwexampleIdp.com/saml",
+        },
+        "saml:Issuer": [
+          { _: "onelogin_saml", $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" } },
+        ],
+        "samlp:NameIDPolicy": [
+          {
+            $: {
+              "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+              Format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+              AllowCreate: "true",
+            },
+          },
+        ],
+        "samlp:RequestedAuthnContext": [
+          {
+            $: { "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol", Comparison: "exact" },
+            "saml:AuthnContextClassRef": [
+              {
+                _: "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+                $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" },
+              },
+            ],
+          },
+        ],
+        "samlp:Extensions": [
+          {
+            "md:RequestedAttribute": [
+              {
+                $: { isRequired: "true", Name: "Lastname" },
+              },
+            ],
+            vetuma: [
+              {
+                $: { xmlns: "urn:vetuma:SAML:2.0:extensions" },
+                LG: ["sv"],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+];
+
+describe("SAML request", function () {
+  function testForCheck(check: SamlCheck) {
+    return function (done: Mocha.Done) {
+      function helper(err: Error | null, samlRequest: Buffer) {
+        try {
+          should.not.exist(err);
+          parseString(samlRequest.toString(), function (err, doc) {
+            try {
+              should.not.exist(err);
+              delete doc["samlp:AuthnRequest"]["$"]["ID"];
+              delete doc["samlp:AuthnRequest"]["$"]["IssueInstant"];
+              doc.should.eql(check.result);
+              done();
+            } catch (err2) {
+              done(err2);
+            }
+          });
+        } catch (err3) {
+          done(err3);
+        }
+      }
+      const oSAML = new SAML(check.config);
+      oSAML.getAuthorizeFormAsync("http://localhost/saml/consume").then((formBody) => {
+        formBody.should.match(/<!DOCTYPE html>[^]*<input.*name="SAMLRequest"[^]*<\/html>/);
+        const samlRequestMatchValues = formBody.match(/<input.*name="SAMLRequest" value="([^"]*)"/);
+        const encodedSamlRequest = samlRequestMatchValues && samlRequestMatchValues[1];
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const buffer = Buffer.from(encodedSamlRequest!, "base64");
+        if (check.config.skipRequestCompression) {
+          return helper(null, buffer);
+        } else {
+          return zlib.inflateRaw(buffer, helper);
+        }
+      });
+    };
+  }
+
+  capturedSamlRequestChecks.forEach(function (check) {
+    it(check.name, testForCheck(check));
+  });
+});


### PR DESCRIPTION
## Issue
close https://github.com/node-saml/passport-saml/issues/602
Linked PR: https://github.com/node-saml/passport-saml/pull/607

## Description

Add support in `passport-saml` where it will allow admin to configure fully customise `<Extensions>` element and add it into SAML Request.

`<Extensions>` element are use to request custom attributes and setting. Its structure and values different as as IDP configurations and requests.

## Use cases
1.  Use `<Extensions>` element to request attributes/data. [More details, oasis-open.org SAML V2.0 Protocol Extension for Requesting Attributes per Request](http://docs.oasis-open.org/security/saml-protoc-req-attr-req/v1.0/saml-protoc-req-attr-req-v1.0.html)
2. Use `<Extensions>` element to request with some custom config. For Example: In [suomi.fi](https://palveluhallinta.suomi.fi/en/tuki/artikkelit/59116c3014bbb10001966f70) idp, its allows SP to request with custom language code by passing it `<Extensions>` element. [More details](https://palveluhallinta.suomi.fi/en/tuki/artikkelit/59116c3014bbb10001966f70)

## Changes

- `src/node-saml/types.ts` : added `extensions` optional variable. The type is `any` and it accept [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) type values because as per use cases and IDPs', there are many cases and each use cases have different request format/data. Please let me know what is your view on this.
-  `src/node-saml/saml.ts`: added it in `request`. As it has already XMLBuilder values so no need to do any processing.
-  Test cases added
-  Docs updated 
-  No Breaking Changes

# Checklist:

- [x] Issue Addressed
- [x] Link to SAML spec
- [x] Tests included
- [x] Documentation updated
