### PR TITLE
add generateUniqueId option and use it for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ const saml = new SAML(options);
 - `skipRequestCompression`: if set to true, the SAML request from the service provider won't be compressed.
 - `authnRequestBinding`: if set to `HTTP-POST`, will request authentication from IDP via HTTP POST binding, otherwise defaults to HTTP Redirect
 - `disableRequestAcsUrl`: if truthy, SAML AuthnRequest from the service provider will not include the optional AssertionConsumerServiceURL. Default is falsy so it is automatically included.
+- `generateUniqueId`: optional function which will be called to generate unique IDs for SAML requests.
 - `scoping`: An optional configuration which implements the functionality [explained in the SAML spec paragraph "3.4.1.2 Element <Scoping>"](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf). The config object is structured as following:
 
 ```javascript

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -111,7 +111,7 @@ async function promiseWithNameID(nameid: Node): Promise<NameID> {
 
 class SAML {
   // note that some methods in SAML are not yet marked as private as they are used in testing.
-  // those methods start with an underscore, e.g. _generateUniqueID
+  // those methods start with an underscore, e.g. _generateLogoutRequest
   options: SamlOptions;
   // This is only for testing
   cacheProvider!: InMemoryCacheProvider;
@@ -197,8 +197,12 @@ class SAML {
     }
   }
 
-  _generateUniqueID() {
-    return crypto.randomBytes(10).toString("hex");
+  private generateUniqueId() {
+    if (this.options.generateUniqueId) {
+      return this.options.generateUniqueId();
+    } else {
+      return "_" + crypto.randomBytes(10).toString("hex");
+    }
   }
 
   private generateInstant() {
@@ -234,7 +238,7 @@ class SAML {
   ): Promise<string | undefined> {
     this.options.entryPoint = assertRequired(this.options.entryPoint, "entryPoint is required");
 
-    const id = "_" + this._generateUniqueID();
+    const id = this.generateUniqueId();
     const instant = this.generateInstant();
 
     if (this.options.validateInResponseTo) {
@@ -361,7 +365,7 @@ class SAML {
   }
 
   async _generateLogoutRequest(user: Profile) {
-    const id = "_" + this._generateUniqueID();
+    const id = this.generateUniqueId();
     const instant = this.generateInstant();
 
     const request = {
@@ -403,7 +407,7 @@ class SAML {
   }
 
   _generateLogoutResponse(logoutRequest: Profile) {
-    const id = "_" + this._generateUniqueID();
+    const id = this.generateUniqueId();
     const instant = this.generateInstant();
 
     const request = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
   scoping?: SamlScopingConfig;
   wantAssertionsSigned?: boolean;
   maxAssertionAgeMs: number;
+  generateUniqueId?(): string;
 
   // InResponseTo Validation
   validateInResponseTo: boolean;

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -26,10 +26,10 @@ describe("node-saml /", function () {
       }).throw("cert is required");
     });
 
-    it("_generateUniqueID should generate 20 char IDs", function () {
+    it("generateUniqueId should generate 21 char IDs", function () {
       const samlObj = new SAML({ entryPoint: "foo", cert: FAKE_CERT });
       for (let i = 0; i < 200; i++) {
-        samlObj._generateUniqueID().length.should.eql(20);
+        samlObj["generateUniqueId"]().length.should.eql(21);
       }
     });
 
@@ -903,11 +903,11 @@ describe("node-saml /", function () {
             customQueryStringParam: "CustomQueryStringParamValue",
           },
           cert: FAKE_CERT,
+          generateUniqueId: function () {
+            return "_12345678901234567890";
+          },
         };
         const samlObj = new SAML(samlConfig);
-        samlObj._generateUniqueID = function () {
-          return "12345678901234567890";
-        };
         const authorizeUrl = await samlObj.getAuthorizeUrlAsync("", "", {});
         const qry = querystring.parse(url.parse(authorizeUrl).query || "");
         qry.SigAlg?.should.match("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
@@ -931,11 +931,11 @@ describe("node-saml /", function () {
             customQueryStringParam: "CustomQueryStringParamValue",
           },
           cert: FAKE_CERT,
+          generateUniqueId: function () {
+            return "_12345678901234567890";
+          },
         };
         const samlObj = new SAML(samlConfig);
-        samlObj._generateUniqueID = function () {
-          return "12345678901234567890";
-        };
 
         const request =
           '<?xml version=\\"1.0\\"?><samlp:AuthnRequest xmlns:samlp=\\"urn:oasis:names:tc:SAML:2.0:protocol\\" ID=\\"_ea40a8ab177df048d645\\" Version=\\"2.0\\" IssueInstant=\\"2017-08-22T19:30:01.363Z\\" ProtocolBinding=\\"urn:oasis:names$tc:SAML:2.0:bindings:HTTP-POST\\" AssertionConsumerServiceURL=\\"https://example.com/login/callback\\" Destination=\\"https://www.example.com\\"><saml:Issuer xmlns:saml=\\"urn:oasis:names:tc:SAML:2.0:assertion\\">onelogin_saml</saml:Issuer><s$mlp:NameIDPolicy xmlns:samlp=\\"urn:oasis:names:tc:SAML:2.0:protocol\\" Format=\\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\\" AllowCreate=\\"true\\"/><samlp:RequestedAuthnContext xmlns:samlp=\\"urn:oasis:names:tc:SAML:2.0:protoc$l\\" Comparison=\\"exact\\"><saml:AuthnContextClassRef xmlns:saml=\\"urn:oasis:names:tc:SAML:2.0:assertion\\">urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp$AuthnRequest>';
@@ -957,11 +957,11 @@ describe("node-saml /", function () {
             customQueryStringParam: "CustomQueryStringParamValue",
           },
           cert: fs.readFileSync(__dirname + "/static/acme_tools_com.cert", "utf-8"),
+          generateUniqueId: function () {
+            return "_12345678901234567890";
+          },
         };
         const samlObj = new SAML(samlConfig);
-        samlObj._generateUniqueID = function () {
-          return "12345678901234567890";
-        };
         const authorizeUrl = await samlObj.getAuthorizeUrlAsync("", "", {});
         const qry = querystring.parse(url.parse(authorizeUrl).query || "");
         qry.SigAlg?.should.match("http://www.w3.org/2000/09/xmldsig#rsa-sha1");
@@ -985,11 +985,11 @@ describe("node-saml /", function () {
             customQueryStringParam: "CustomQueryStringParamValue",
           },
           cert: FAKE_CERT,
+          generateUniqueId: function () {
+            return "_12345678901234567890";
+          },
         };
         const samlObj = new SAML(samlConfig);
-        samlObj._generateUniqueID = function () {
-          return "12345678901234567890";
-        };
         const authorizeUrl = await samlObj.getAuthorizeUrlAsync("", "", {});
         const qry = querystring.parse(url.parse(authorizeUrl).query || "");
         qry.SigAlg?.should.match("http://www.w3.org/2000/09/xmldsig#rsa-sha1");


### PR DESCRIPTION
# Description

Make the _generateUniqueID function private, and exposed via an option to override it for testing and other purposes, instead of being public and hot-patched in the tests.

This will also allow library users to change the way unique IDs are generated.

`notes:`
* old IDs were always prefixed by an underscore before use (it isn't clear why this was, but possibly because some ID providers don't like IDs starting with a number?). Now the underscore is included in the generation function, so if mimicking the build-in gnerateUniqueID function be sure to include a leading underscore in the function provided as the option value.

* because of this, the length of IDs generated is now checked to be 21, instead of 20, in the test.

* Changed name of now-private method to generateUniqueId to be consistent with other naming (note lowercase d in Id)

