### PR TITLE
#13 GCM EncryptionMethod

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -1399,8 +1399,8 @@ class SAML {
           },
           EncryptionMethod: [
             // this should be the set that the xmlenc library supports
-            { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#aes256-gcm" },
-            { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#aes128-gcm" },
+            { "@Algorithm": "http://www.w3.org/2009/xmlenc11#aes256-gcm" },
+            { "@Algorithm": "http://www.w3.org/2009/xmlenc11#aes128-gcm" },
             { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#aes256-cbc" },
             { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#aes128-cbc" },
           ],

--- a/test/static/expected metadata.xml
+++ b/test/static/expected metadata.xml
@@ -33,8 +33,8 @@ nwtlCg==
 </ds:X509Certificate>
         </ds:X509Data>
       </ds:KeyInfo>
-      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-gcm"/>
-      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-gcm"/>
+      <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
+      <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
       <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
       <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
     </KeyDescriptor>

--- a/test/static/expectedMetadataWithBothKeys.xml
+++ b/test/static/expectedMetadataWithBothKeys.xml
@@ -55,8 +55,8 @@ nwtlCg==
 </ds:X509Certificate>
         </ds:X509Data>
       </ds:KeyInfo>
-      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-gcm"/>
-      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-gcm"/>
+      <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
+      <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
       <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
       <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
     </KeyDescriptor>


### PR DESCRIPTION
# Description

This PR addresses the bug mentioned in #13. It updates the algorithms referenced to the correct paths, and updates relevant tests:

`http://www.w3.org/2001/04/xmlenc#aes256-gcm` > `http://www.w3.org/2009/xmlenc11#aes256-gcm`
`http://www.w3.org/2001/04/xmlenc#aes128-gcm` >  `http://www.w3.org/2009/xmlenc11#aes128-gcm`

# Checklist:

- Issue Addressed: [X]
- Link to SAML spec: [X] ([XML Encryption Syntax and Processing Version 1.1](https://www.w3.org/TR/xmlenc-core1/#sec-AES-GCM))
- Tests included? [X]
- Documentation updated? [X] (No changes found)
