### PR TITLE
Set AuthnRequestsSigned in SP metadata if configured for signing.

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -460,7 +460,7 @@ class SAML {
     Object.keys(additionalParameters).forEach((k) => {
       samlMessage[k] = additionalParameters[k];
     });
-    if (this.options.privateKey != null) {
+    if (isValidSamlSigningOptions(this.options)) {
       if (!this.options.entryPoint) {
         throw new Error('"entryPoint" config parameter is required for signed messages');
       }
@@ -1347,7 +1347,9 @@ class SAML {
 
     if (this.options.decryptionPvk != null || this.options.privateKey != null) {
       metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = [];
-      if (this.options.privateKey != null) {
+      if (isValidSamlSigningOptions(this.options)) {
+        metadata.EntityDescriptor.SPSSODescriptor["@AuthnRequestsSigned"] = true;
+
         signingCert = removeCertPEMHeaderAndFooter(signingCert!);
 
         metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor.push({

--- a/test/static/acme_tools_com.xml
+++ b/test/static/acme_tools_com.xml
@@ -1,5 +1,5 @@
 <EntityDescriptor entityID="acme_tools_com" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true">
     <KeyDescriptor use="signing">
       <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
         <ds:X509Data>

--- a/test/static/expectedMetadataWithBothKeys.xml
+++ b/test/static/expectedMetadataWithBothKeys.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
-  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true">
     <KeyDescriptor use="signing">
       <ds:KeyInfo>
         <ds:X509Data>

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -424,6 +424,23 @@ describe("node-saml /", function () {
       metadata.should.containEql('WantAssertionsSigned="true"');
     });
 
+    it("generateServiceProviderMetadata contains AuthnRequestsSigned", function () {
+      const samlConfig = {
+        cert: TEST_CERT,
+        issuer: "http://example.serviceprovider.com",
+        callbackUrl: "http://example.serviceprovider.com/saml/callback",
+        identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+        privateKey: fs.readFileSync(__dirname + "/static/acme_tools_com.key"),
+        wantAssertionsSigned: true,
+      };
+
+      const samlObj = new SAML(samlConfig);
+      const signingCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
+
+      const metadata = samlObj.generateServiceProviderMetadata(null, signingCert);
+      metadata.should.containEql('AuthnRequestsSigned="true"');
+    });
+
     describe("validatePostResponse checks /", function () {
       let fakeClock: sinon.SinonFakeTimers;
 


### PR DESCRIPTION
# Description

This PR adds the AuthnRequestsSigned attribute to the SPSSODescriptor in SP metadata when the SP has been configured to sign requests.

Currently if both the `options.privateKey` is set, and a signing cert is passed to `generateServiceProviderMetadata`, the requests will be signed.  The metadata should be indicating this behavior with `AuthnRequestsSigned="true"`.

The SAML spec states in 2.4.4 (https://www.oasis-open.org/committees/download.php/56785/sstc-saml-metadata-errata-2.0-wd-05.pdf):
> AuthnRequestsSigned [Optional]
> Optional attribute that indicates whether the <samlp:AuthnRequest> messages sent by this
> service provider will be signed. If omitted, the value is assumed to be false. [E7]A value of
> false (or omission of this attribute) does not imply that the service provider will never sign its
> requests or that a signed request should be considered an error. However, an identity provider
> that receives an unsigned <samlp:AuthnRequest> message from a service provider whose
> metadata contains this attribute with a value of true MUST return a SAML error response and
> MUST NOT fulfill the request.

If requests will be signed, it would be better if this attribute was set to require the IdP to reject unsigned requests.  Effectively, this enables a more secure by default behavior.

# Checklist:

- Issue Addressed: [ ]
- Link to SAML spec: [ x]
- Tests included? [x ]
- Documentation updated? [N/A ]
