### PR TITLE
fix(validatePostResponseAsync): support missing NotOnOrAfter in SubjectConfirmationData

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -1423,6 +1423,9 @@ class SAML {
     notOnOrAfter: string,
     issueInstant: string
   ): number {
+    if (!notOnOrAfter) {
+      return 0;
+    }
     const notOnOrAfterMs = dateStringToTimestamp(notOnOrAfter, "NotOnOrAfter");
     const issueInstantMs = dateStringToTimestamp(issueInstant, "IssueInstant");
 


### PR DESCRIPTION
# Description

Address a regression introduced by https://github.com/node-saml/node-saml/commit/54a1e0457f8e59a9b6947894072f7f9fb2bf8387. `NotOnOrAfter` and `NotBefore` are optional according to the specification (see https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf, `2.4.1.2 Element <SubjectConfirmationData>`). This minimal change returns a 0 value for `processMaxAgeAssertionTime`, compatible with `checkTimestampsValidityError` which already handles optional `notBefore` and `notOnOrAfter` attributes.

# Checklist:

- Issue Addressed: [ ]
- Link to SAML spec: [x]
- Tests included? [x]
- Documentation updated? [ ]
