### PR TITLE
Add ability to publish multiple signing certs in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,7 @@ As a convenience, the strategy object exposes a `generateServiceProviderMetadata
 
 The `decryptionCert` argument should be a public certificate matching the `decryptionPvk` and is required if the strategy is configured with a `decryptionPvk`.
 
-The `signingCert` argument should be a public certificate matching the `privateKey` and is required if the strategy is configured with a `privateKey`.
-
-The `generateServiceProviderMetadata` method is also available on the `MultiSamlStrategy`, but needs an extra request and a callback argument (`generateServiceProviderMetadata( req, decryptionCert, signingCert, next )`), which are passed to the `getSamlOptions` to retrieve the correct configuration.
+The `signingCert` argument should be a public certificate matching the `privateKey` and is required if the strategy is configured with a `privateKey`. An array of certificates can be provided to support certificate rotation. When supplying an array of certificates, the first entry in the array should match the current `privateKey`. Additional entries in the array can be used to publish upcoming certificates to IdPs before changing the `privateKey`.
 
 ## Security and signatures
 

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -1333,7 +1333,7 @@ class SAML {
 
   generateServiceProviderMetadata(
     decryptionCert: string | null,
-    signingCert?: string | null
+    signingCert?: string | string[] | null
   ): string {
     const metadata: ServiceMetadataXML = {
       EntityDescriptor: {
@@ -1350,7 +1350,7 @@ class SAML {
     if (this.options.decryptionPvk != null || this.options.privateKey != null) {
       metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = [];
       if (isValidSamlSigningOptions(this.options)) {
-        if (typeof signingCert !== "string") {
+        if (!signingCert) {
           throw new Error(
             "Missing signingCert while generating metadata for signing service provider messages"
           );
@@ -1358,18 +1358,18 @@ class SAML {
 
         metadata.EntityDescriptor.SPSSODescriptor["@AuthnRequestsSigned"] = true;
 
-        signingCert = removeCertPEMHeaderAndFooter(signingCert);
-
-        metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor.push({
+        const certArray = Array.isArray(signingCert) ? signingCert : [signingCert];
+        const signingKeyDescriptors = certArray.map((cert) => ({
           "@use": "signing",
           "ds:KeyInfo": {
             "ds:X509Data": {
               "ds:X509Certificate": {
-                "#text": signingCert,
+                "#text": removeCertPEMHeaderAndFooter(cert),
               },
             },
           },
-        });
+        }));
+        metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor.push(signingKeyDescriptors);
       }
 
       if (this.options.decryptionPvk != null) {

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -1350,11 +1350,10 @@ class SAML {
     if (this.options.decryptionPvk != null || this.options.privateKey != null) {
       metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = [];
       if (isValidSamlSigningOptions(this.options)) {
-        if (!signingCert) {
-          throw new Error(
-            "Missing signingCert while generating metadata for signing service provider messages"
-          );
-        }
+        signingCert = assertRequired(
+          signingCert,
+          "Missing signingCert while generating metadata for signing service provider messages"
+        );
 
         metadata.EntityDescriptor.SPSSODescriptor["@AuthnRequestsSigned"] = true;
 
@@ -1373,11 +1372,10 @@ class SAML {
       }
 
       if (this.options.decryptionPvk != null) {
-        if (!decryptionCert) {
-          throw new Error(
-            "Missing decryptionCert while generating metadata for decrypting service provider"
-          );
-        }
+        decryptionCert = assertRequired(
+          decryptionCert,
+          "Missing decryptionCert while generating metadata for decrypting service provider"
+        );
 
         decryptionCert = removeCertPEMHeaderAndFooter(decryptionCert);
 

--- a/test/static/expectedMetadataWithEncryptionAndTwoSigningKeys.xml
+++ b/test/static/expectedMetadataWithEncryptionAndTwoSigningKeys.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
+  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true">
+    <KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>MIICrjCCAZYCCQDWybyUsLVkXzANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDFA5h
+Y21lX3Rvb2xzLmNvbTAeFw0xNTA4MTgwODQ3MzZaFw0yNTA4MTcwODQ3MzZaMBkx
+FzAVBgNVBAMUDmFjbWVfdG9vbHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAlyT+OzEymhaZFNfx4+HFxZbBP3egvcUgPvGa7wWCV7vyuCauLBqw
+O1FQqzaRDxkEihkHqmUz63D25v2QixLxXyqaFQ8TxDFKwYATtSL7x5G2Gww56H0L
+1XGgYdNW1akPx90P+USmVn1Wb//7AwU+TV+u4jIgKZyTaIFWdFlwBhlp4OBEHCyY
+wngFgMyVoCBsSmwb4if7Mi5T746J9ZMQpC+ts+kfzley59Nz55pa5fRLwu4qxFUv
+2oRdXAf2ZLuxB7DPQbRH82/ewZZ8N4BUGiQyAwOsHgp0sb9JJ8uEM/qhyS1dXXxj
+o+kxsI5HXhxp4P5R9VADuOquaLIo8ptIrQIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
+AQBW/Y7leJnV76+6bzeqqi+buTLyWc1mASi5LVH68mdailg2WmGfKlSMLGzFkNtg
+8fJnfaRZ/GtxmSxhpQRHn63ZlyzqVrFcJa0qzPG21PXPHG/ny8pN+BV8fk74CIb/
++YN7NvDUrV7jlsPxNT2rQk8G2fM7jsTMYvtz0MBkrZZsUzTv4rZkF/v44J/ACDir
+KJiE+TYArm70yQPweX6RvYHNZLSzgg4o+hoyBXo5BGQetAjmcIhC6ZOwN3iVhGjp
+0YpWM0pkqStPy3sIR0//LZbskWWlSRb0fX1c4632Xb+zikfec4DniYV6CxkB2U+p
+lHpOX1rt1R+UiTEIhTSXPNt/
+</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </KeyDescriptor>
+    <KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>MIIDtTCCAp2gAwIBAgIJAKg4VeVcIDz1MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+BAYTAlVTMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX
+aWRnaXRzIFB0eSBMdGQwHhcNMTUwODEzMDE1NDIwWhcNMTUwOTEyMDE1NDIwWjBF
+MQswCQYDVQQGEwJVUzETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50
+ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAxG3ouM7U+fXbJt69X1H6d4UNg/uRr06pFuU9RkfIwNC+yaXyptqB3ynX
+KsL7BFt4DCd0fflRvJAx3feJIDp16wN9GDVHcufWMYPhh2j5HcTW/j9JoIJzGhJy
+vO00YKBt+hHy83iN1SdChKv5y0iSyiPP5GnqFw+ayyHoM6hSO0PqBou1Xb0ZSIE+
+DHosBnvVna5w2AiPY4xrJl9yZHZ4Q7DfMiYTgstjETio4bX+6oLiBnYktn7DjdEs
+lqhffVme4PuBxNojI+uCeg/sn4QVLd/iogMJfDWNuLD8326Mi/FE9cCRvFlvAiMS
+aebMI3zPaySsxTK7Zgj5TpEbmbHI9wIDAQABo4GnMIGkMB0GA1UdDgQWBBSVGgvo
+W4MhMuzBGce29PY8vSzHFzB1BgNVHSMEbjBsgBSVGgvoW4MhMuzBGce29PY8vSzH
+F6FJpEcwRTELMAkGA1UEBhMCVVMxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV
+BAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAKg4VeVcIDz1MAwGA1UdEwQF
+MAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJu1rqs+anD74dbdwgd3CnqnQsQDJiEX
+mBhG2leaGt3ve9b/9gKaJg2pyb2NyppDe1uLqh6nNXDuzg1oNZrPz5pJL/eCXPl7
+FhxhMUi04TtLf8LeNTCIWYZiFuO4pmhohHcv8kRvYR1+6SkLTC8j/TZerm7qvesS
+iTQFNapa1eNdVQ8nFwVkEtWl+JzKEM1BlRcn42sjJkijeFp7DpI7pU+PnYeiaXpR
+v5pJo8ogM1iFxN+SnfEs0EuQ7fhKIG9aHKi7bKZ7L6SyX7MDIGLeulEU6lf5D9Bf
+XNmcMambiS0pXhL2QXajt96UBq8FT2KNXY8XNtR4y6MyyCzhaiZZcc8=
+</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </KeyDescriptor>
+    <KeyDescriptor use="encryption">
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>MIIEsDCCApigAwIBAgIBADANBgkqhkiG9w0BAQUFADATMREwDwYDVQQDEwgxMC4w
+LjEuNDAeFw0xNDA1MDgwMDU0MTlaFw0xNDA1MDgwMDU0MTlaMBMxETAPBgNVBAMT
+CDEwLjAuMS40MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5hqjaroJ
+pB+aR8FME7hQ9nMV0h7MpKtmgFLcK3vwP67feAK+xdt17i8RyUhxil9FCFR5K08W
+jwo3NiHZqHqEKitw+IJSndjLSsoNgKEIaiFSug2eV1oYElz06DBXTxc8iq/Laznd
+qTUom51Ode9yI9AGa88cDM5iOqq9mhuGuvwuLtoyU78Ld+s1Ea6Mgf7L8M7fZVO7
+Ncu+FgIzI6Gt035ohYCLBmOoM7o0uj7DcMEvKOMFziwF40wYmyp3hCLlq3qwkM9p
+TVJltuz0Bt1vqDdrq3kTheA9JHMayRz3I/BZxAV3iRd4hzLKTkegD8ToTGU10Gme
++ZAr1w/erc5hVrM0/XBmHQlnI5d31GU/mfIkm0XPTGRSpPy7E+dUvj9djvm/VqDd
+ojf3uuwirGeLMRlO9P/lCerTktW3g27SV8gn3ETm2Mm7rkNqf24KJpDv0tKDosgb
+daHr2IEYD4RpqySp8kd25BhzushqKRkS8Xu5t7HAlVSHwiFhuLqrr4dUfkB8kZeM
+/ycfZLCn7oNUDFdgjGYSVMpakL97sC9slAW4/8UtXXZxLqcyq/YxdpCysPYP1hsA
+p+VgPC7GI6CyiNojKPOptMqLZRYnViKxlOiWBJBzUBRUVuac8LXrMiDw8btWGa1G
+h5vThuFUKsvmRoeuk7eyXEN9J7j6+fTYjnsCAwEAAaMPMA0wCwYDVR0PBAQDAgTw
+MA0GCSqGSIb3DQEBBQUAA4ICAQDAPFUo0Pga7vB4Ijy9u3qpWLQSCd4xfw8l92iq
+3JqLVXBx8Gf9XVy6GzbXWIe6pmQIzmom/CWQvh6o7kc0F4y4ftsWfqnq3k0+HcX4
+Heu1PN2HSnUUPNsk5Adggd3129MHIdfaKb8bSuLJvSMeMaycrmsb+gEF6JFP8kGW
+OP4xQYjAVODcFbOyAfEuVAhujw0bqlLHT+El4vlfBrtdU+MZztIqQkGDW7cmm86Z
+GiBr/ga97BCnOCrgZXlrgmia8SmF7Rfa48/Xzh7bDmPfgmHglL5JxhpRX2IoPY5X
+ItmR8IaYKhOBOrO/qercJ6Z3rQ6fIrs8HrYgeTO/uE9ww6WRWCWDaCR4oWDVwjKz
+GfP1oJtAIQ+UNjOddH5otDawXJRlQWpr72qT7+WOK/yzJhN0xmXDkmt5psMY/CDn
+4kXMM0xaRpfYOn5Sc1oelQ+hIm8/rHVK/0krhCDOniqj+L/ne2SoyoXYgS6o0Nlk
+NhtTHmjjosE7HV6JfAUgq2D9dq00JO967I3P0VF6F8lcdaq0tovJhKWRjrrigYd7
+56/3aT2B83JWA1RA9niXmrXfnAPZrNCfWvj+X2alUN/izdIqRts0UpWToVUr0ozW
+gmbmp5ZOGYOQh+lNcAp3V9lOrdbZVSITM47RYGBZaZNDA2PbDzC13MS/EjTEvSko
+nwtlCg==
+</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+      <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
+      <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+    </KeyDescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+    <AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
+  </SPSSODescriptor>
+</EntityDescriptor>

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -322,7 +322,7 @@ describe("node-saml /", function () {
       function testMetadata(
         samlConfig: SamlConfig,
         expectedMetadata: string,
-        signingCert?: string
+        signingCert?: string | string[]
       ) {
         const samlObj = new SAML(samlConfig);
         const decryptionCert = fs.readFileSync(
@@ -420,7 +420,7 @@ describe("node-saml /", function () {
         testMetadata(samlConfig, expectedMetadata, signingCert);
       });
 
-      it("config with protocol, path, host, decryptionPvk and privateKey should pass", function () {
+      it("config with encryption and two signing certificates should pass", function () {
         const samlConfig = {
           issuer: "http://example.serviceprovider.com",
           protocol: "http://",
@@ -432,12 +432,15 @@ describe("node-saml /", function () {
           cert: FAKE_CERT,
         };
         const expectedMetadata = fs.readFileSync(
-          __dirname + "/static/expectedMetadataWithBothKeys.xml",
+          __dirname + "/static/expectedMetadataWithEncryptionAndTwoSigningKeys.xml",
           "utf-8"
         );
-        const signingCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
+        const signingCerts = [
+          fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString(),
+          fs.readFileSync(__dirname + "/static/cert.pem").toString(),
+        ];
 
-        testMetadata(samlConfig, expectedMetadata, signingCert);
+        testMetadata(samlConfig, expectedMetadata, signingCerts);
       });
     });
 


### PR DESCRIPTION
# Description

This PR adds the ability to publish multiple signing certificates in SP metadata.  The primary use case for this is certificate rotation or rollover.  IdPs that support metadata polling/refresh will accept new signing certificates and allow an SP to rotate their signing certificate with no downtime or coordinated metadata updates.

The SAML spec does not address this specifically other than to allow multiple KeyDescriptors in an SSODescriptor.   Most well established SAML software solutions support and use multiple signing keys in metadata, attempting to use any when validating signatures.

The concept is outlined in this doc.  While written for a Shibboleth Idp, the general procedure is the same for an SP: https://shibboleth.atlassian.net/wiki/spaces/SHIB2/pages/2577072227/IdPKeyRollover

# Checklist:

- Issue Addressed: [X]
- Link to SAML spec: [ ]
- Tests included? [X]
- Documentation updated? [X]
