### PR TITLE
Add option to sign generated metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const saml = new SAML(options);
 - `disableRequestAcsUrl`: if truthy, SAML AuthnRequest from the service provider will not include the optional AssertionConsumerServiceURL. Default is falsy so it is automatically included.
 - `generateUniqueId`: optional function which will be called to generate unique IDs for SAML requests.
 - `scoping`: An optional configuration which implements the functionality [explained in the SAML spec paragraph "3.4.1.2 Element <Scoping>"](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf). The config object is structured as following:
-- `signMetadata`: if truthy, adds a signature to the generated Service Provider metadata. `privateKey` must be set to use this option.
+- `signMetadata`: if true, adds a signature to the generated Service Provider metadata. `privateKey` must be set to use this option.
 
 ```javascript
 {

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ const saml = new SAML(options);
 - `disableRequestAcsUrl`: if truthy, SAML AuthnRequest from the service provider will not include the optional AssertionConsumerServiceURL. Default is falsy so it is automatically included.
 - `generateUniqueId`: optional function which will be called to generate unique IDs for SAML requests.
 - `scoping`: An optional configuration which implements the functionality [explained in the SAML spec paragraph "3.4.1.2 Element <Scoping>"](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf). The config object is structured as following:
+- `signMetadata`: if truthy, adds a signature to the generated Service Provider metadata. `privateKey` must be set to use this option.
 
 ```javascript
 {

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -1410,7 +1410,7 @@ class SAML {
     };
 
     let metadataXml = buildXmlBuilderObject(metadata, true);
-    if (this.options.signMetadata && isValidSamlSigningOptions(this.options)) {
+    if (this.options.signMetadata === true && isValidSamlSigningOptions(this.options)) {
       metadataXml = signXmlMetadata(metadataXml, this.options);
     }
     return metadataXml;

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -27,7 +27,7 @@ import {
   XMLOutput,
 } from "./types";
 import { AuthenticateOptions, AuthorizeOptions } from "./passport-saml-types";
-import { assertRequired } from "./utility";
+import { assertRequired, signXmlMetadata } from "./utility";
 import {
   buildXml2JsObject,
   buildXmlBuilderObject,
@@ -1408,7 +1408,12 @@ class SAML {
       "@Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
       "@Location": this.getCallbackUrl(),
     };
-    return buildXmlBuilderObject(metadata, true);
+
+    let metadataXml = buildXmlBuilderObject(metadata, true);
+    if (this.options.signMetadata && isValidSamlSigningOptions(this.options)) {
+      metadataXml = signXmlMetadata(metadataXml, this.options);
+    }
+    return metadataXml;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,7 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
   wantAssertionsSigned?: boolean;
   maxAssertionAgeMs: number;
   generateUniqueId: () => string;
+  signMetadata?: boolean;
 
   // InResponseTo Validation
   validateInResponseTo: boolean;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -20,3 +20,15 @@ export function signXmlResponse(samlMessage: string, options: SamlSigningOptions
     options
   );
 }
+
+export function signXmlMetadata(metadataXml: string, options: SamlSigningOptions): string {
+  const metadataXpath =
+    '//*[local-name(.)="EntityDescriptor" and namespace-uri(.)="urn:oasis:names:tc:SAML:2.0:metadata"]';
+
+  return signXml(
+    metadataXml,
+    metadataXpath,
+    { reference: metadataXpath, action: "prepend" },
+    options
+  );
+}

--- a/test/static/signedMetadata.xml
+++ b/test/static/signedMetadata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com"><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#http___example_serviceprovider_com"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>6OtPTHBsvLIKFr++9gEzMSzGp16WbYt68YtRmKvb29A=</DigestValue></Reference></SignedInfo><SignatureValue>fP9p+HZud8budVt2XeGD5DSr9x8hEn7hxLvP8/dPMCAF3tnh5yfYsSl32nej/dZhJpSiavMyTbtKUkH9t6WhjUVumZ9ReuSnG5CLHLqbpzw+XNWi5+EEIy6B+U0MhVUU8NapuWBAHEbao2dHnlpVvkGgeukFf29/4PVx5O0QWU67g/D7rG+N7bAcAhe+eRwRheDxg1M8lb9xUCmaClUTfopW0U4KyR14u82ynpzj/3DtHQmvRqKIT3ID8KPLUDmxlijzUevEjJaMlkeq/gFJJHEYOyIwczfBqaNIKmcDf93M1870YGJ3Ox/2Wgz1/s24d9XjSbye6y32yWBr95H0RQ==</SignatureValue></Signature>
+  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true" WantAssertionsSigned="true">
+    <KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>MIICrjCCAZYCCQDWybyUsLVkXzANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDFA5h
+Y21lX3Rvb2xzLmNvbTAeFw0xNTA4MTgwODQ3MzZaFw0yNTA4MTcwODQ3MzZaMBkx
+FzAVBgNVBAMUDmFjbWVfdG9vbHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAlyT+OzEymhaZFNfx4+HFxZbBP3egvcUgPvGa7wWCV7vyuCauLBqw
+O1FQqzaRDxkEihkHqmUz63D25v2QixLxXyqaFQ8TxDFKwYATtSL7x5G2Gww56H0L
+1XGgYdNW1akPx90P+USmVn1Wb//7AwU+TV+u4jIgKZyTaIFWdFlwBhlp4OBEHCyY
+wngFgMyVoCBsSmwb4if7Mi5T746J9ZMQpC+ts+kfzley59Nz55pa5fRLwu4qxFUv
+2oRdXAf2ZLuxB7DPQbRH82/ewZZ8N4BUGiQyAwOsHgp0sb9JJ8uEM/qhyS1dXXxj
+o+kxsI5HXhxp4P5R9VADuOquaLIo8ptIrQIDAQABMA0GCSqGSIb3DQEBCwUAA4IB
+AQBW/Y7leJnV76+6bzeqqi+buTLyWc1mASi5LVH68mdailg2WmGfKlSMLGzFkNtg
+8fJnfaRZ/GtxmSxhpQRHn63ZlyzqVrFcJa0qzPG21PXPHG/ny8pN+BV8fk74CIb/
++YN7NvDUrV7jlsPxNT2rQk8G2fM7jsTMYvtz0MBkrZZsUzTv4rZkF/v44J/ACDir
+KJiE+TYArm70yQPweX6RvYHNZLSzgg4o+hoyBXo5BGQetAjmcIhC6ZOwN3iVhGjp
+0YpWM0pkqStPy3sIR0//LZbskWWlSRb0fX1c4632Xb+zikfec4DniYV6CxkB2U+p
+lHpOX1rt1R+UiTEIhTSXPNt/
+</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </KeyDescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+    <AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
+  </SPSSODescriptor>
+</EntityDescriptor>

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -463,7 +463,7 @@ describe("node-saml /", function () {
         metadata.split("\n").should.eql(expectedMetadata.split("\n"));
 
         const dom = parseDomFromString(metadata);
-        samlObj.validateSignature(metadata, dom.documentElement, [signingCert]);
+        samlObj.validateSignature(metadata, dom.documentElement, [signingCert]).should.be.true;
       });
     });
 

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -12,6 +12,7 @@ import assert = require("assert");
 import { FAKE_CERT, TEST_CERT } from "./types";
 import { signXmlResponse } from "../src/utility";
 import * as crypto from "../src/crypto";
+import { parseDomFromString } from "../src/xml";
 
 export const BAD_TEST_CERT =
   "MIIEOTCCAyGgAwIBAgIJAKZgJdKdCdL6MA0GCSqGSIb3DQEBBQUAMHAxCzAJBgNVBAYTAkFVMREwDwYDVQQIEwhWaWN0b3JpYTESMBAGA1UEBxMJTWVsYm91cm5lMSEwHwYDVQQKExhUYWJjb3JwIEhvbGRpbmdzIExpbWl0ZWQxFzAVBgNVBAMTDnN0cy50YWIuY29tLmF1MB4XDTE3MDUzMDA4NTQwOFoXDTI3MDUyODA4NTQwOFowcDELMAkGA1UEBhMCQVUxETAPBgNVBAgTCFZpY3RvcmlhMRIwEAYDVQQHEwlNZWxib3VybmUxITAfBgNVBAoTGFRhYmNvcnAgSG9sZGluZ3MgTGltaXRlZDEXMBUGA1UEAxMOc3RzLnRhYi5jb20uYXUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQD0NuMcflq3rtupKYDf4a7lWmsXy66fYe9n8jB2DuLMakEJBlzn9j6B98IZftrilTq21VR7wUXROxG8BkN8IHY+l8X7lATmD28fFdZJj0c8Qk82eoq48faemth4fBMx2YrpnhU00jeXeP8dIIaJTPCHBTNgZltMMhphklN1YEPlzefJs3YD+Ryczy1JHbwETxt+BzO1JdjBe1fUTyl6KxAwWvtsNBURmQRYlDOk4GRgdkQnfxBuCpOMeOpV8wiBAi3h65Lab9C5avu4AJlA9e4qbOmWt6otQmgy5fiJVy6bH/d8uW7FJmSmePX9sqAWa9szhjdn36HHVQsfHC+IUEX7AgMBAAGjgdUwgdIwHQYDVR0OBBYEFN6z6cuxY7FTkg1S/lIjnS4x5ARWMIGiBgNVHSMEgZowgZeAFN6z6cuxY7FTkg1S/lIjnS4x5ARWoXSkcjBwMQswCQYDVQQGEwJBVTERMA8GA1UECBMIVmljdG9yaWExEjAQBgNVBAcTCU1lbGJvdXJuZTEhMB8GA1UEChMYVGFiY29ycCBIb2xkaW5ncyBMaW1pdGVkMRcwFQYDVQQDEw5zdHMudGFiLmNvbS5hdYIJAKZgJdKdCdL6MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAMi5HyvXgRa4+kKz3dk4SwAEXzeZRcsbeDJWVUxdb6a+JQxIoG7L9rSbd6yZvP/Xel5TrcwpCpl5eikzXB02/C0wZKWicNmDEBlOfw0Pc5ngdoh6ntxHIWm5QMlAfjR0dgTlojN4Msw2qk7cP1QEkV96e2BJUaqaNnM3zMvd7cfRjPNfbsbwl6hCCCAdwrALKYtBnjKVrCGPwO+xiw5mUJhZ1n6ZivTOdQEWbl26UO60J9ItiWP8VK0d0aChn326Ovt7qC4S3AgDlaJwcKe5Ifxl/UOWePGRwXj2UUuDWFhjtVmRntMmNZbe5yE8MkEvU+4/c6LqGwTCgDenRbK53Dgg";
@@ -383,62 +384,87 @@ describe("node-saml /", function () {
 
         testMetadata(samlConfig, expectedMetadata, signingCert);
       });
-    });
 
-    it("generateServiceProviderMetadata contains logout callback url", function () {
-      const samlConfig = {
-        issuer: "http://example.serviceprovider.com",
-        callbackUrl: "http://example.serviceprovider.com/saml/callback",
-        identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-        decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
-        logoutCallbackUrl: "http://example.serviceprovider.com/logout",
-        cert: FAKE_CERT,
-      };
+      it("generateServiceProviderMetadata contains logout callback url", function () {
+        const samlConfig = {
+          issuer: "http://example.serviceprovider.com",
+          callbackUrl: "http://example.serviceprovider.com/saml/callback",
+          identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+          decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
+          logoutCallbackUrl: "http://example.serviceprovider.com/logout",
+          cert: FAKE_CERT,
+        };
 
-      const samlObj = new SAML(samlConfig);
-      const decryptionCert = fs.readFileSync(
-        __dirname + "/static/testshib encryption cert.pem",
-        "utf-8"
-      );
-      const metadata = samlObj.generateServiceProviderMetadata(decryptionCert);
-      metadata.should.containEql("SingleLogoutService");
-      metadata.should.containEql(samlConfig.logoutCallbackUrl);
-    });
+        const samlObj = new SAML(samlConfig);
+        const decryptionCert = fs.readFileSync(
+          __dirname + "/static/testshib encryption cert.pem",
+          "utf-8"
+        );
+        const metadata = samlObj.generateServiceProviderMetadata(decryptionCert);
+        metadata.should.containEql("SingleLogoutService");
+        metadata.should.containEql(samlConfig.logoutCallbackUrl);
+      });
 
-    it("generateServiceProviderMetadata contains WantAssertionsSigned", function () {
-      const samlConfig = {
-        cert: TEST_CERT,
-        issuer: "http://example.serviceprovider.com",
-        callbackUrl: "http://example.serviceprovider.com/saml/callback",
-        identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-        decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
-        wantAssertionsSigned: true,
-      };
+      it("generateServiceProviderMetadata contains WantAssertionsSigned", function () {
+        const samlConfig = {
+          cert: TEST_CERT,
+          issuer: "http://example.serviceprovider.com",
+          callbackUrl: "http://example.serviceprovider.com/saml/callback",
+          identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+          decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
+          wantAssertionsSigned: true,
+        };
 
-      const samlObj = new SAML(samlConfig);
-      const decryptionCert = fs.readFileSync(
-        __dirname + "/static/testshib encryption cert.pem",
-        "utf-8"
-      );
-      const metadata = samlObj.generateServiceProviderMetadata(decryptionCert);
-      metadata.should.containEql('WantAssertionsSigned="true"');
-    });
+        const samlObj = new SAML(samlConfig);
+        const decryptionCert = fs.readFileSync(
+          __dirname + "/static/testshib encryption cert.pem",
+          "utf-8"
+        );
+        const metadata = samlObj.generateServiceProviderMetadata(decryptionCert);
+        metadata.should.containEql('WantAssertionsSigned="true"');
+      });
 
-    it("generateServiceProviderMetadata contains AuthnRequestsSigned", function () {
-      const samlConfig = {
-        cert: TEST_CERT,
-        issuer: "http://example.serviceprovider.com",
-        callbackUrl: "http://example.serviceprovider.com/saml/callback",
-        identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-        privateKey: fs.readFileSync(__dirname + "/static/acme_tools_com.key"),
-        wantAssertionsSigned: true,
-      };
+      it("generateServiceProviderMetadata contains AuthnRequestsSigned", function () {
+        const samlConfig = {
+          cert: TEST_CERT,
+          issuer: "http://example.serviceprovider.com",
+          callbackUrl: "http://example.serviceprovider.com/saml/callback",
+          identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+          privateKey: fs.readFileSync(__dirname + "/static/acme_tools_com.key"),
+          wantAssertionsSigned: true,
+        };
 
-      const samlObj = new SAML(samlConfig);
-      const signingCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
+        const samlObj = new SAML(samlConfig);
+        const signingCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
 
-      const metadata = samlObj.generateServiceProviderMetadata(null, signingCert);
-      metadata.should.containEql('AuthnRequestsSigned="true"');
+        const metadata = samlObj.generateServiceProviderMetadata(null, signingCert);
+        metadata.should.containEql('AuthnRequestsSigned="true"');
+      });
+
+      it("signMetadata creates a valid signature", function () {
+        const samlConfig: SamlConfig = {
+          cert: TEST_CERT,
+          issuer: "http://example.serviceprovider.com",
+          callbackUrl: "http://example.serviceprovider.com/saml/callback",
+          identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+          privateKey: fs.readFileSync(__dirname + "/static/acme_tools_com.key"),
+          wantAssertionsSigned: true,
+          signMetadata: true,
+          signatureAlgorithm: "sha256",
+          digestAlgorithm: "sha256",
+        };
+
+        const samlObj = new SAML(samlConfig);
+        const signingCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
+
+        const expectedMetadata = fs.readFileSync(__dirname + "/static/signedMetadata.xml", "utf-8");
+
+        const metadata = samlObj.generateServiceProviderMetadata(null, signingCert);
+        metadata.split("\n").should.eql(expectedMetadata.split("\n"));
+
+        const dom = parseDomFromString(metadata);
+        samlObj.validateSignature(metadata, dom.documentElement, [signingCert]);
+      });
     });
 
     describe("validatePostResponse checks /", function () {


### PR DESCRIPTION
# Description

As a follow on for #23, this PR adds the ability to sign generated metadata.   This is an added security measure when doing signing certificate rotations or other metadata sharing.

With this option enabled, IdPs that poll for metadata updates can now verify the metadata with the existing signing certificates it has configured before accepting new certs.  This prevents an attack vector from man-in-the-middle or compromised metadata hosting locations (assuming the signing cert private key was not also compromised).

# Checklist:

- Issue Addressed: [X]
- Link to SAML spec: [ ]
- Tests included? [X]
- Documentation updated? [X]
