### PR TITLE
Set a unique ID value in generated metadata

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -1365,7 +1365,7 @@ class SAML {
         "@xmlns": "urn:oasis:names:tc:SAML:2.0:metadata",
         "@xmlns:ds": "http://www.w3.org/2000/09/xmldsig#",
         "@entityID": this.options.issuer,
-        "@ID": this.options.issuer.replace(/\W/g, "_"),
+        "@ID": this.options.generateUniqueId(),
         SPSSODescriptor: {
           "@protocolSupportEnumeration": "urn:oasis:names:tc:SAML:2.0:protocol",
         },

--- a/test/static/expected metadata without key.xml
+++ b/test/static/expected metadata without key.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="d700077e-60ad-49c1-b93a-dd1753528708">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
     <AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>

--- a/test/static/expected metadata.xml
+++ b/test/static/expected metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="d700077e-60ad-49c1-b93a-dd1753528708">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <KeyDescriptor use="encryption">
       <ds:KeyInfo>

--- a/test/static/expectedMetadataWithBothKeys.xml
+++ b/test/static/expectedMetadataWithBothKeys.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="d700077e-60ad-49c1-b93a-dd1753528708">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true">
     <KeyDescriptor use="signing">
       <ds:KeyInfo>

--- a/test/static/expectedMetadataWithEncryptionAndTwoSigningKeys.xml
+++ b/test/static/expectedMetadataWithEncryptionAndTwoSigningKeys.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="d700077e-60ad-49c1-b93a-dd1753528708">
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true">
     <KeyDescriptor use="signing">
       <ds:KeyInfo>


### PR DESCRIPTION
# Description

When generating SAML metadata, the ID created in the `EntityDescriptor` element is generated based on the issuer value.  The intent of the ID value is to be unique for a document so if you were to change properties of your SP, the different metadata versions should not have the same ID.   While it is unlikely that this ID is being used as a cache control mechanism, it should change if the metadata changes.  Most common implementations generate a new ID each time metadata is generated, and this change does the same.

SAML core spec **1.3.4 ID and ID Reference Values**:
> Any party that assigns an identifier MUST ensure that there is negligible probability that that party or
any other party will accidentally assign the same identifier to a different data object



# Checklist:

- Issue Addressed: [x]
- Link to SAML spec: [x]
- Tests included? [x]
- Documentation updated? [n/a]
