### PR TITLE
Updates validateInResponseTo option to accept a string in addition to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ const saml = new SAML(options);
 ```
 
 - **InResponseTo Validation**
-- `validateInResponseTo`: if truthy, then InResponseTo will be validated from incoming SAML responses
+- `validateInResponseTo`: If set to "always", will require inResponseTo (will not support IDP logins); if set to "onlyIfPresent", will validate InResponseTo from incoming SAML responses only if present; if set to "never", will skip validation. Truthy converts to "always", and falsy converts to "never" for backwards compatibility
 - `requestIdExpirationPeriodMs`: Defines the expiration time when a Request ID generated for a SAML request will not be valid if seen in a SAML response in the `InResponseTo` field. Default is 8 hours.
 - `cacheProvider`: Defines the implementation for a cache provider used to store request Ids generated in SAML requests as part of `InResponseTo` validation. Default is a built-in in-memory cache provider. For details see the 'Cache Provider' section.
 - **Issuer Validation**

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,7 +122,7 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
   signMetadata?: boolean;
 
   // InResponseTo Validation
-  validateInResponseTo: boolean;
+  validateInResponseTo: boolean | string;
   requestIdExpirationPeriodMs: number;
   cacheProvider: CacheProvider;
 


### PR DESCRIPTION
… a boolean. Increases the functionality of validateInResponseTo to 'always', 'onlyIfPresent', and 'never'. See node-saml/passport-saml#329.

# Description

Thank you for taking the time to create a PR to support this community-maintained project. We are all volunteers here, so features are only added by contributers like you. Please also be patient while the maintainers work to review your proposed changes for quality and effacy.

Please include a _summary of the change_ and, where appropriate, _which issue is addressed_.

Your description should also include a _comment about the use-case_ for this change, including what systems you may be interfacing with that require this change. This will help future users know how this library is being used in the wild and how well supported it is.

If the change involves the SAML specification, please _include a link to the relavent part(s) of the SAML specificaiton_. Doing so speeds up the review process and helps the maintainers make sure that this project remains spec-compliant. You might start [here](https://www.oasis-open.org/standards#samlv2.0) to find the part of the specificaiton that relates to this PR.

_Please include tests._ Doing so will ensure that the changes made in this PR are not undone or otherwise corrupted by future changes.

# Checklist:

- Issue Addressed: [x]
- Link to SAML spec: [n/a]
- Tests included? [ x]
- Documentation updated? [x ]
