### PR TITLE
Upgrade xml-encryption to 2.0.0 (fixes audit issue)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3483,11 +3483,6 @@
         "is-stream": "^1.0.1"
       }
     },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
-    },
     "nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
@@ -9694,13 +9689,12 @@
       }
     },
     "xml-encryption": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.3.0.tgz",
-      "integrity": "sha512-3P8C4egMMxSR1BmsRM+fG16a3WzOuUEQKS2U4c3AZ5v7OseIfdUeVkD8dwxIhuLryFZSRWUL5OP6oqkgU7hguA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-2.0.0.tgz",
+      "integrity": "sha512-4Av83DdvAgUQQMfi/w8G01aJshbEZP9ewjmZMpS9t3H+OCZBDvyK4GJPnHGfWiXlArnPbYvR58JB9qF2x9Ds+Q==",
       "requires": {
         "@xmldom/xmldom": "^0.7.0",
         "escape-html": "^1.0.3",
-        "node-forge": "^0.10.0",
         "xpath": "0.0.32"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@xmldom/xmldom": "^0.7.2",
     "debug": "^4.3.1",
     "xml-crypto": "^2.1.3",
-    "xml-encryption": "^1.3.0",
+    "xml-encryption": "^2.0.0",
     "xml2js": "^0.4.23",
     "xmlbuilder": "^15.1.1"
   },

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -2188,7 +2188,7 @@ describe("node-saml /", function () {
       ),
     };
     await assert.rejects(samlObj.validatePostRequestAsync(body), {
-      message: "Invalid RSAES-OAEP padding.",
+      message: "error:04099079:rsa routines:RSA_padding_check_PKCS1_OAEP_mgf1:oaep decoding error",
     });
   });
 


### PR DESCRIPTION
This PR resolves the node-forge issue reported by `npm audit`.

The interface of xml-encryption has not changed. The only differences
are the node-forge dependency being dropped and the required Node
version being incremented to 12 (already required by node-saml).

The implementation changes in xml-encryption mean that it now produces
errors from Node rather than node-forge.