### PR TITLE
remove useless not null assertions on errors

### DIFF
--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -749,18 +749,18 @@ describe("node-saml /", function () {
         it("must have a cert to construct a SAML object", function () {
           try {
             new SAML(noCertSamlConfig);
-          } catch (err: any) {
+          } catch (err) {
             expect(err).to.exist;
-            expect(err!.message!).to.match(/cert is required/);
+            expect(err.message).to.match(/cert is required/);
           }
         });
 
         it("must have a valid cert to construct a SAML object", function () {
           try {
             new SAML(badCertSamlConfig);
-          } catch (err: any) {
+          } catch (err) {
             expect(err).to.exist;
-            expect(err!.message!).to.match(/cert is required/);
+            expect(err.message).to.match(/cert is required/);
           }
         });
 
@@ -789,9 +789,9 @@ describe("node-saml /", function () {
           const container = { SAMLResponse: base64xml };
           try {
             const samlObj = new SAML(noCertSamlConfig);
-          } catch (err: any) {
+          } catch (err) {
             expect(err).to.exist;
-            expect(err!.message!).to.match(/cert is required/);
+            expect(err.message).to.match(/cert is required/);
           }
         });
 
@@ -959,9 +959,9 @@ describe("node-saml /", function () {
           try {
             await samlObj.validatePostResponseAsync(container);
             expect(true).to.not.exist;
-          } catch (err: any) {
+          } catch (err) {
             expect(err).to.exist;
-            expect(err!).to.equal(errorToReturn);
+            expect(err).to.equal(errorToReturn);
           }
         });
 
@@ -1565,8 +1565,8 @@ describe("node-saml /", function () {
         try {
           const { profile } = await samlObj.validatePostResponseAsync(container);
           expect(profile).to.not.exist;
-        } catch (err: any) {
-          expect(err!.message).to.eq("InResponseTo is missing from response");
+        } catch (err) {
+          expect(err.message).to.eq("InResponseTo is missing from response");
         }
       });
 

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -749,18 +749,20 @@ describe("node-saml /", function () {
         it("must have a cert to construct a SAML object", function () {
           try {
             new SAML(noCertSamlConfig);
-          } catch (err) {
+          } catch (err: unknown) {
             expect(err).to.exist;
-            expect(err.message).to.match(/cert is required/);
+            expect(err).to.be.instanceOf(Error);
+            expect((err as Error).message).to.match(/cert is required/);
           }
         });
 
         it("must have a valid cert to construct a SAML object", function () {
           try {
             new SAML(badCertSamlConfig);
-          } catch (err) {
+          } catch (err: unknown) {
             expect(err).to.exist;
-            expect(err.message).to.match(/cert is required/);
+            expect(err).to.be.instanceOf(Error);
+            expect((err as Error).message).to.match(/cert is required/);
           }
         });
 
@@ -791,7 +793,7 @@ describe("node-saml /", function () {
             const samlObj = new SAML(noCertSamlConfig);
           } catch (err) {
             expect(err).to.exist;
-            expect(err.message).to.match(/cert is required/);
+            expect((err as Error).message).to.match(/cert is required/);
           }
         });
 
@@ -1565,8 +1567,9 @@ describe("node-saml /", function () {
         try {
           const { profile } = await samlObj.validatePostResponseAsync(container);
           expect(profile).to.not.exist;
-        } catch (err) {
-          expect(err.message).to.eq("InResponseTo is missing from response");
+        } catch (err: unknown) {
+          expect(err).to.be.instanceOf(Error);
+          expect((err as Error).message).to.eq("InResponseTo is missing from response");
         }
       });
 


### PR DESCRIPTION
# Description

Removes not null assertions on errors in tests, because they are not necessary.

# Checklist:

- Issue Addressed: [ ]
- Link to SAML spec: [ ]
- Tests included? [ ]
- Documentation updated? [ ]
