### PR TITLE
remove useless any type declaration

### DIFF
--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -2132,8 +2132,8 @@ describe("node-saml /", function () {
     });
   });
   describe("validatePostRequest()", function () {
-    const signingKey: any = fs.readFileSync(__dirname + "/static/key.pem", "ascii");
-    const signingCert: any = fs.readFileSync(__dirname + "/static/cert.pem", "ascii");
+    const signingKey = fs.readFileSync(__dirname + "/static/key.pem", "ascii");
+    const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "ascii");
     let samlObj: SAML;
 
     beforeEach(function () {


### PR DESCRIPTION
# Description

It is not necessary to specify the type of these variables, as ` readFileSync`  returns a `string`.

# Checklist:

- Issue Addressed: [ ]
- Link to SAML spec: [ ]
- Tests included? [ ]
- Documentation updated? [ ]
