### PR TITLE
Correctly reset Sinon fake timers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2244,9 +2244,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.1.tgz",
-      "integrity": "sha512-Wp5vwlZ0lOqpSYGKqr53INws9HLkt6JDc/pDZcPf7bchQnrXJMXPns8CXx0hFikMSGSWfvtvvpb2gtMVfkWagA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -6555,13 +6555,13 @@
       "dev": true
     },
     "sinon": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.1.tgz",
-      "integrity": "sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-13.0.2.tgz",
+      "integrity": "sha512-KvOrztAVqzSJWMDoxM4vM+GPys1df2VBoXm+YciyB/OLMamfS3VXh3oGh5WtrAGSzrgczNWFFY22oKb7Fi5eeA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^9.0.0",
+        "@sinonjs/fake-timers": "^9.1.2",
         "@sinonjs/samsam": "^6.1.1",
         "diff": "^5.0.0",
         "nise": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "prettier-plugin-packagejson": "^2.2.17",
     "release-it": "^14.14.0",
     "request": "^2.83.0",
-    "sinon": "^13.0.1",
+    "sinon": "^13.0.2",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.3"
   },

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -1823,6 +1823,7 @@ describe("node-saml /", function () {
       describe("InResponseTo server cache expiration tests /", () => {
         it("should expire a cached request id after the time", async () => {
           const requestId = "_dfab47d5d46374cd4b71";
+          fakeClock = sinon.useFakeTimers();
 
           const samlConfig: SamlConfig = {
             validateInResponseTo: ValidateInResponseTo.always,

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -613,7 +613,6 @@ describe("node-saml /", function () {
 
       afterEach(() => {
         if (fakeClock) {
-          // If fakeClock is retored in a test, it will cause intermittant problems for other tests
           fakeClock.restore();
         }
       });
@@ -1171,9 +1170,11 @@ describe("node-saml /", function () {
 
     describe("getAuthorizeUrl request signature checks /", function () {
       let fakeClock: sinon.SinonFakeTimers;
+
       beforeEach(function () {
         fakeClock = sinon.useFakeTimers(Date.parse("2014-05-28T00:13:09Z"));
       });
+
       afterEach(function () {
         fakeClock.restore();
       });
@@ -1834,7 +1835,7 @@ describe("node-saml /", function () {
           // Mock the SAML request being passed through Passport-SAML
           await samlObj.cacheProvider.saveAsync(requestId, new Date().toISOString());
 
-          await (() => new Promise((resolve) => setTimeout(resolve, 300)))();
+          await fakeClock.tickAsync(300);
           const value = await samlObj.cacheProvider.getAsync(requestId);
           expect(value).to.not.exist;
         });
@@ -1843,6 +1844,7 @@ describe("node-saml /", function () {
           const expiredRequestId1 = "_dfab47d5d46374cd4b71";
           const expiredRequestId2 = "_dfab47d5d46374cd4b72";
           const requestId = "_dfab47d5d46374cd4b73";
+          fakeClock = sinon.useFakeTimers();
 
           const samlConfig: SamlConfig = {
             validateInResponseTo: ValidateInResponseTo.always,
@@ -1855,7 +1857,7 @@ describe("node-saml /", function () {
           await samlObj.cacheProvider.saveAsync(expiredRequestId1, new Date().toISOString());
           await samlObj.cacheProvider.saveAsync(expiredRequestId2, new Date().toISOString());
 
-          await new Promise((resolve) => setTimeout(resolve, 300));
+          await fakeClock.tickAsync(300);
           // Add one more that shouldn't expire
           await samlObj.cacheProvider.saveAsync(requestId, new Date().toISOString());
 
@@ -1865,7 +1867,7 @@ describe("node-saml /", function () {
           expect(value2).to.not.exist;
           const value3 = await samlObj.cacheProvider.getAsync(requestId);
           expect(value3).to.exist;
-          await (() => new Promise((resolve) => setTimeout(resolve, 300)))();
+          await fakeClock.tickAsync(300);
           const value4 = await samlObj.cacheProvider.getAsync(requestId);
           expect(value4).to.not.exist;
         });


### PR DESCRIPTION
During some testing of the tests, it was found that some tests randomly failed. Diagnosis revealed it was because we were overwriting the `fakeClock` variable at times and therefore were not correctly `restore`ing the built-in timers, causing problems for following tests. This will fix that.

The pattern followed is to allow a `describe` blocks `beforeEach` and `afterEach` to set up and tear down fake timers if, and only if, each child `it` block needs the same fake timer. In every other case a `try...finally` block was used in the `it` block to build a local fake timer and tear it down, no matter what failures the test might experience.