### PR TITLE
Stop using import assignments

### DIFF
--- a/test/crypto.spec.ts
+++ b/test/crypto.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import { expect } from "chai";
-import assert = require("assert");
+import * as assert from "assert";
 import { certToPEM, generateUniqueId, keyToPEM } from "../src/crypto";
 import { TEST_CERT } from "./types";
 import { assertRequired } from "../src/utility";

--- a/test/test-signatures.spec.ts
+++ b/test/test-signatures.spec.ts
@@ -2,7 +2,7 @@ import { SAML } from "../src";
 import * as fs from "fs";
 import * as sinon from "sinon";
 import { SamlConfig } from "../src/types";
-import assert = require("assert");
+import * as assert from "assert";
 import { expect } from "chai";
 
 const cert = fs.readFileSync(__dirname + "/static/cert.pem", "ascii");


### PR DESCRIPTION
# Description

Import assignment cannot be used when targeting ECMAScript modules.