### PR TITLE
Remove unused `qs` types

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@types/mocha": "^9.1.0",
     "@types/node": "^14.18.12",
     "@types/passport": "^1.0.7",
-    "@types/qs": "^6.9.7",
     "@types/sinon": "^10.0.11",
     "@types/xml-crypto": "^1.4.2",
     "@types/xml-encryption": "^1.2.1",


### PR DESCRIPTION
# Description

Remove unused types for `qs` library. The `qs` library is no longer used by this project.