### PR TITLE
Move dependency types next to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2306,7 +2306,6 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -2334,7 +2333,6 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -2343,7 +2341,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
       "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dev": true,
       "requires": {
         "@types/ms": "*"
       }
@@ -2352,7 +2349,6 @@
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
       "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -2364,7 +2360,6 @@
       "version": "4.17.28",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
       "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -2405,8 +2400,7 @@
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
-      "dev": true
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -2423,14 +2417,12 @@
     "@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-      "dev": true
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
       "version": "14.18.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
-      "dev": true
+      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -2442,7 +2434,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.7.tgz",
       "integrity": "sha512-JtswU8N3kxBYgo+n9of7C97YQBT+AYPP2aBfNGTzABqPAZnK/WOAaKfh3XesUYMZRrXFuoPc2Hv0/G/nQFveHw==",
-      "dev": true,
       "requires": {
         "@types/express": "*"
       }
@@ -2450,14 +2441,12 @@
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/responselike": {
       "version": "1.0.0",
@@ -2472,7 +2461,6 @@
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
       "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
-      "dev": true,
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -2497,7 +2485,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/xml-crypto/-/xml-crypto-1.4.2.tgz",
       "integrity": "sha512-1kT+3gVkeBDg7Ih8NefxGYfCApwZViMIs5IEs5AXF6Fpsrnf9CLAEIRh0DYb1mIcRcvysVbe27cHsJD6rJi36w==",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "xpath": "0.0.27"
@@ -2506,8 +2493,7 @@
         "xpath": {
           "version": "0.0.27",
           "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-          "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==",
-          "dev": true
+          "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
         }
       }
     },
@@ -2515,16 +2501,14 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/xml-encryption/-/xml-encryption-1.2.1.tgz",
       "integrity": "sha512-UeyZkfZFZSa9XCGU5uGgUmsSLwQESDJvF076bJGyDf2gkXJjKvK8fW/x4ckvEHB2M/5RHJEkMc5xI+JrdmCTKA==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/xml2js": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.9.tgz",
-      "integrity": "sha512-CHiCKIihl1pychwR2RNX5mAYmJDACgFVCMT5OArMaO3erzwXVcBqPcusr+Vl8yeeXukxZqtF8mZioqX+mpjjdw==",
-      "dev": true,
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.11.tgz",
+      "integrity": "sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==",
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
     "watch": "concurrently --kill-others \"npm:*-watch\""
   },
   "dependencies": {
+    "@types/debug": "^4.1.7",
+    "@types/passport": "^1.0.7",
+    "@types/xml-crypto": "^1.4.2",
+    "@types/xml-encryption": "^1.2.1",
+    "@types/xml2js": "^0.4.11",
     "@xmldom/xmldom": "^0.8.1",
     "debug": "^4.3.4",
     "xml-crypto": "^2.1.3",
@@ -61,14 +66,9 @@
   "devDependencies": {
     "@cjbarth/github-release-notes": "^1.0.1",
     "@types/chai": "^4.3.0",
-    "@types/debug": "^4.1.7",
     "@types/mocha": "^9.1.0",
     "@types/node": "^14.18.12",
-    "@types/passport": "^1.0.7",
     "@types/sinon": "^10.0.11",
-    "@types/xml-crypto": "^1.4.2",
-    "@types/xml-encryption": "^1.2.1",
-    "@types/xml2js": "^0.4.9",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
     "body-parser": "^1.19.2",


### PR DESCRIPTION
# Description

According to the TypeScript [documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies), since this package is designed to be imported by others, the types for `dependencies` should be next to the dependencies themselves. This PR moves the `@types` dependencies from `devDependencies` to `dependencies`.