### PR TITLE
Factor out metadata routines

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -22,14 +22,13 @@ import {
   SamlIDPEntryConfig,
   SamlOptions,
   SamlConfig,
-  ServiceMetadataXML,
   XMLInput,
   XMLObject,
   XMLOutput,
   ValidateInResponseTo,
 } from "./types";
 import { AuthenticateOptions, AuthorizeOptions } from "./passport-saml-types";
-import { assertRequired, signXmlMetadata } from "./utility";
+import { assertRequired } from "./utility";
 import {
   buildXml2JsObject,
   buildXmlBuilderObject,
@@ -39,9 +38,10 @@ import {
   validateXmlSignatureForCert,
   xpath,
 } from "./xml";
-import { certToPEM, generateUniqueId, keyToPEM, removeCertPEMHeaderAndFooter } from "./crypto";
+import { certToPEM, generateUniqueId, keyToPEM } from "./crypto";
 import { dateStringToTimestamp, generateInstant } from "./datetime";
 import { getAdditionalParams } from "./saml/common";
+import { generateServiceProviderMetadata } from "./saml/metadata";
 
 const inflateRawAsync = util.promisify(zlib.inflateRaw);
 const deflateRawAsync = util.promisify(zlib.deflateRaw);
@@ -1355,99 +1355,16 @@ class SAML {
 
   generateServiceProviderMetadata(
     decryptionCert: string | null,
-    signingCert?: string | string[] | null
+    signingCerts?: string | string[] | null
   ): string {
-    const metadata: ServiceMetadataXML = {
-      EntityDescriptor: {
-        "@xmlns": "urn:oasis:names:tc:SAML:2.0:metadata",
-        "@xmlns:ds": "http://www.w3.org/2000/09/xmldsig#",
-        "@entityID": this.options.issuer,
-        "@ID": this.options.generateUniqueId(),
-        SPSSODescriptor: {
-          "@protocolSupportEnumeration": "urn:oasis:names:tc:SAML:2.0:protocol",
-        },
-      },
-    };
+    const callbackUrl = this.getCallbackUrl(); // TODO it would probably be useful to have a host parameter here
 
-    if (this.options.decryptionPvk != null || this.options.privateKey != null) {
-      metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = [];
-      if (isValidSamlSigningOptions(this.options)) {
-        assertRequired(
-          signingCert,
-          "Missing signingCert while generating metadata for signing service provider messages"
-        );
-
-        metadata.EntityDescriptor.SPSSODescriptor["@AuthnRequestsSigned"] = true;
-
-        const certArray = Array.isArray(signingCert) ? signingCert : [signingCert];
-        const signingKeyDescriptors = certArray.map((cert) => ({
-          "@use": "signing",
-          "ds:KeyInfo": {
-            "ds:X509Data": {
-              "ds:X509Certificate": {
-                "#text": removeCertPEMHeaderAndFooter(cert),
-              },
-            },
-          },
-        }));
-        metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor.push(signingKeyDescriptors);
-      }
-
-      if (this.options.decryptionPvk != null) {
-        assertRequired(
-          decryptionCert,
-          "Missing decryptionCert while generating metadata for decrypting service provider"
-        );
-
-        decryptionCert = removeCertPEMHeaderAndFooter(decryptionCert);
-
-        metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor.push({
-          "@use": "encryption",
-          "ds:KeyInfo": {
-            "ds:X509Data": {
-              "ds:X509Certificate": {
-                "#text": decryptionCert,
-              },
-            },
-          },
-          EncryptionMethod: [
-            // this should be the set that the xmlenc library supports
-            { "@Algorithm": "http://www.w3.org/2009/xmlenc11#aes256-gcm" },
-            { "@Algorithm": "http://www.w3.org/2009/xmlenc11#aes128-gcm" },
-            { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#aes256-cbc" },
-            { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#aes128-cbc" },
-          ],
-        });
-      }
-    }
-
-    if (this.options.logoutCallbackUrl != null) {
-      metadata.EntityDescriptor.SPSSODescriptor.SingleLogoutService = {
-        "@Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-        "@Location": this.options.logoutCallbackUrl,
-      };
-    }
-
-    if (this.options.identifierFormat != null) {
-      metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
-    }
-
-    if (this.options.wantAssertionsSigned) {
-      metadata.EntityDescriptor.SPSSODescriptor["@WantAssertionsSigned"] = true;
-    }
-
-    metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
-      "@index": "1",
-      "@isDefault": "true",
-      "@Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-      "@Location": this.getCallbackUrl(),
-    };
-
-    let metadataXml = buildXmlBuilderObject(metadata, true);
-    if (this.options.signMetadata === true && isValidSamlSigningOptions(this.options)) {
-      metadataXml = signXmlMetadata(metadataXml, this.options);
-    }
-    return metadataXml;
+    return generateServiceProviderMetadata({
+      ...this.options,
+      callbackUrl,
+      decryptionCert,
+      signingCerts,
+    });
   }
 
   /**

--- a/src/saml/metadata.ts
+++ b/src/saml/metadata.ts
@@ -1,0 +1,154 @@
+import { removeCertPEMHeaderAndFooter } from "../crypto";
+import { SamlOptions, isValidSamlSigningOptions, ServiceMetadataXML, XMLObject } from "../types";
+import { assertRequired, signXmlMetadata } from "../utility";
+import { buildXmlBuilderObject } from "../xml";
+
+interface GenerateServiceProviderMetadataParams {
+  decryptionCert?: string | null;
+  signingCerts?: string | string[] | null;
+  issuer: SamlOptions["issuer"];
+  callbackUrl: SamlOptions["callbackUrl"];
+  logoutCallbackUrl?: SamlOptions["logoutCallbackUrl"];
+  identifierFormat?: SamlOptions["identifierFormat"];
+  wantAssertionsSigned: SamlOptions["wantAssertionsSigned"];
+  decryptionPvk?: SamlOptions["decryptionPvk"];
+  privateKey?: SamlOptions["privateKey"];
+  signatureAlgorithm?: SamlOptions["signatureAlgorithm"];
+  xmlSignatureTransforms?: SamlOptions["xmlSignatureTransforms"];
+  digestAlgorithm?: SamlOptions["digestAlgorithm"];
+  signMetadata?: SamlOptions["signMetadata"];
+}
+
+export const generateServiceProviderMetadata = (
+  params: GenerateServiceProviderMetadataParams
+): string => {
+  const {
+    issuer,
+    callbackUrl,
+    logoutCallbackUrl,
+    identifierFormat,
+    wantAssertionsSigned,
+    decryptionPvk,
+    privateKey,
+  } = params;
+
+  let { signingCerts, decryptionCert } = params;
+
+  if (decryptionPvk != null) {
+    if (!decryptionCert) {
+      throw new Error(
+        "Missing decryptionCert while generating metadata for decrypting service provider"
+      );
+    }
+  } else {
+    decryptionCert = null;
+  }
+
+  if (privateKey != null) {
+    if (!signingCerts) {
+      throw new Error(
+        "Missing signingCert while generating metadata for signing service provider messages"
+      );
+    }
+    signingCerts = !Array.isArray(signingCerts) ? [signingCerts] : signingCerts;
+  } else {
+    signingCerts = null;
+  }
+
+  const metadata: ServiceMetadataXML = {
+    EntityDescriptor: {
+      "@xmlns": "urn:oasis:names:tc:SAML:2.0:metadata",
+      "@xmlns:ds": "http://www.w3.org/2000/09/xmldsig#",
+      "@entityID": issuer,
+      "@ID": issuer.replace(/\W/g, "_"),
+      SPSSODescriptor: {
+        "@protocolSupportEnumeration": "urn:oasis:names:tc:SAML:2.0:protocol",
+      },
+    },
+  };
+
+  if (decryptionCert != null || signingCerts != null) {
+    metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = [];
+    if (isValidSamlSigningOptions(params)) {
+      assertRequired(
+        signingCerts,
+        "Missing signingCert while generating metadata for signing service provider messages"
+      );
+
+      metadata.EntityDescriptor.SPSSODescriptor["@AuthnRequestsSigned"] = true;
+
+      const certArray = Array.isArray(signingCerts) ? signingCerts : [signingCerts];
+      const signingKeyDescriptors = certArray.map((cert) => ({
+        "@use": "signing",
+        "ds:KeyInfo": {
+          "ds:X509Data": {
+            "ds:X509Certificate": {
+              "#text": removeCertPEMHeaderAndFooter(cert),
+            },
+          },
+        },
+      }));
+      metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor.push(signingKeyDescriptors);
+    }
+
+    if (decryptionPvk != null) {
+      assertRequired(
+        decryptionCert,
+        "Missing decryptionCert while generating metadata for decrypting service provider"
+      );
+
+      decryptionCert = removeCertPEMHeaderAndFooter(decryptionCert);
+
+      metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor.push({
+        "@use": "encryption",
+        "ds:KeyInfo": {
+          "ds:X509Data": {
+            "ds:X509Certificate": {
+              "#text": decryptionCert,
+            },
+          },
+        },
+        EncryptionMethod: [
+          // this should be the set that the xmlenc library supports
+          { "@Algorithm": "http://www.w3.org/2009/xmlenc11#aes256-gcm" },
+          { "@Algorithm": "http://www.w3.org/2009/xmlenc11#aes128-gcm" },
+          { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#aes256-cbc" },
+          { "@Algorithm": "http://www.w3.org/2001/04/xmlenc#aes128-cbc" },
+        ],
+      });
+    }
+  }
+
+  if (logoutCallbackUrl != null) {
+    metadata.EntityDescriptor.SPSSODescriptor.SingleLogoutService = {
+      "@Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+      "@Location": logoutCallbackUrl,
+    };
+  }
+
+  if (identifierFormat != null) {
+    metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = identifierFormat;
+  }
+
+  if (wantAssertionsSigned) {
+    metadata.EntityDescriptor.SPSSODescriptor["@WantAssertionsSigned"] = true;
+  }
+
+  metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
+    "@index": "1",
+    "@isDefault": "true",
+    "@Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+    "@Location": callbackUrl,
+  } as XMLObject;
+
+  let metadataXml = buildXmlBuilderObject(metadata, true);
+  if (params.signMetadata === true && isValidSamlSigningOptions(params)) {
+    metadataXml = signXmlMetadata(metadataXml, {
+      privateKey: params.privateKey,
+      signatureAlgorithm: params.signatureAlgorithm,
+      xmlSignatureTransforms: params.xmlSignatureTransforms,
+      digestAlgorithm: params.digestAlgorithm,
+    });
+  }
+  return metadataXml;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,7 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
   // Additional SAML behaviors
   additionalParams: Record<string, string>;
   additionalAuthorizeParams: Record<string, string>;
-  identifierFormat?: string | null;
+  identifierFormat: string | null;
   allowCreate: boolean;
   spNameQualifier?: string | null;
   acceptedClockSkewMs: number;
@@ -124,7 +124,7 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
   idpIssuer?: string;
   audience: string | false;
   scoping?: SamlScopingConfig;
-  wantAssertionsSigned?: boolean;
+  wantAssertionsSigned: boolean;
   maxAssertionAgeMs: number;
   generateUniqueId: () => string;
   signMetadata?: boolean;


### PR DESCRIPTION
# Description

In the spirit of https://github.com/node-saml/node-saml/pull/19, migrate out metadata code from `saml.ts`. This doesn't touch any tests, which can be factored out later.