### PR TITLE
Fix broken request tests

### DIFF
--- a/test/samlRequest.spec.ts
+++ b/test/samlRequest.spec.ts
@@ -8,7 +8,7 @@ import { SamlConfig } from "../src/types";
 import * as assert from "assert";
 
 describe("SAML request", function () {
-  it("Config with Extensions", function () {
+  it("Config with Extensions", async function () {
     const config: SamlConfig = {
       entryPoint: "https://wwwexampleIdp.com/saml",
       cert: FAKE_CERT,
@@ -25,7 +25,7 @@ describe("SAML request", function () {
           },
         },
       },
-      issuer: "onesaml_login",
+      issuer: "onelogin_saml",
     };
 
     const result = {
@@ -86,7 +86,7 @@ describe("SAML request", function () {
     };
 
     const oSAML = new SAML(config);
-    oSAML
+    return oSAML
       .getAuthorizeFormAsync("http://localhost/saml/consume")
       .then((formBody) => {
         expect(formBody).to.match(/<!DOCTYPE html>[^]*<input.*name="SAMLRequest"[^]*<\/html>/);
@@ -104,15 +104,15 @@ describe("SAML request", function () {
       .then((doc) => {
         delete doc["samlp:AuthnRequest"]["$"]["ID"];
         delete doc["samlp:AuthnRequest"]["$"]["IssueInstant"];
-        expect(doc).to.equal(result);
+        expect(doc).to.deep.equal(result);
       });
   });
 
-  it("AllowCreate defaults to true", function () {
+  it("AllowCreate defaults to true", async function () {
     const config: SamlConfig = {
       entryPoint: "https://wwwexampleIdp.com/saml",
       cert: FAKE_CERT,
-      issuer: "onesaml_login",
+      issuer: "onelogin_saml",
     };
 
     const result = {
@@ -123,6 +123,143 @@ describe("SAML request", function () {
           ProtocolBinding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
           AssertionConsumerServiceURL: "http://localhost/saml/consume",
           Destination: "https://wwwexampleIdp.com/saml",
+        },
+        "saml:Issuer": [
+          { _: "onelogin_saml", $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" } },
+        ],
+        "samlp:NameIDPolicy": [
+          {
+            $: {
+              "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+              Format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+              AllowCreate: "true",
+            },
+          },
+        ],
+        "samlp:RequestedAuthnContext": [
+          {
+            $: { "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol", Comparison: "exact" },
+            "saml:AuthnContextClassRef": [
+              {
+                _: "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+                $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const oSAML = new SAML(config);
+    return oSAML
+      .getAuthorizeFormAsync("http://localhost/saml/consume")
+      .then((formBody) => {
+        expect(formBody).to.match(/<!DOCTYPE html>[^]*<input.*name="SAMLRequest"[^]*<\/html>/);
+        const samlRequestMatchValues = formBody.match(/<input.*name="SAMLRequest" value="([^"]*)"/);
+        assertRequired(samlRequestMatchValues?.[1]);
+        const encodedSamlRequest = samlRequestMatchValues?.[1];
+
+        let buffer = Buffer.from(encodedSamlRequest, "base64");
+        if (!config.skipRequestCompression) {
+          buffer = zlib.inflateRawSync(buffer);
+        }
+
+        return parseStringPromise(buffer.toString());
+      })
+      .then((doc) => {
+        delete doc["samlp:AuthnRequest"]["$"]["ID"];
+        delete doc["samlp:AuthnRequest"]["$"]["IssueInstant"];
+        expect(doc).to.deep.equal(result);
+      });
+  });
+
+  it("Config with NameIDPolicy options", async function () {
+    const config: SamlConfig = {
+      entryPoint: "https://wwwexampleIdp.com/saml",
+      cert: FAKE_CERT,
+      issuer: "onelogin_saml",
+      identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+      allowCreate: false,
+      spNameQualifier: "https://exampleaffiliation.com/saml",
+    };
+
+    const result = {
+      "samlp:AuthnRequest": {
+        $: {
+          "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+          Version: "2.0",
+          ProtocolBinding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+          AssertionConsumerServiceURL: "http://localhost/saml/consume",
+          Destination: "https://wwwexampleIdp.com/saml",
+        },
+        "saml:Issuer": [
+          { _: "onelogin_saml", $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" } },
+        ],
+        "samlp:NameIDPolicy": [
+          {
+            $: {
+              "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+              Format: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+              AllowCreate: "false",
+              SPNameQualifier: "https://exampleaffiliation.com/saml",
+            },
+          },
+        ],
+        "samlp:RequestedAuthnContext": [
+          {
+            $: { "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol", Comparison: "exact" },
+            "saml:AuthnContextClassRef": [
+              {
+                _: "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+                $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const oSAML = new SAML(config);
+    return oSAML
+      .getAuthorizeFormAsync("http://localhost/saml/consume")
+      .then((formBody) => {
+        expect(formBody).to.match(/<!DOCTYPE html>[^]*<input.*name="SAMLRequest"[^]*<\/html>/);
+        const samlRequestMatchValues = formBody.match(/<input.*name="SAMLRequest" value="([^"]*)"/);
+        assertRequired(samlRequestMatchValues?.[1]);
+        const encodedSamlRequest = samlRequestMatchValues?.[1];
+
+        let buffer = Buffer.from(encodedSamlRequest, "base64");
+        if (!config.skipRequestCompression) {
+          buffer = zlib.inflateRawSync(buffer);
+        }
+
+        return parseStringPromise(buffer.toString());
+      })
+      .then((doc) => {
+        delete doc["samlp:AuthnRequest"]["$"]["ID"];
+        delete doc["samlp:AuthnRequest"]["$"]["IssueInstant"];
+        expect(doc).to.deep.equal(result);
+      });
+  });
+
+  it("Config with forceAuthn and passive", async function () {
+    const config: SamlConfig = {
+      entryPoint: "https://wwwexampleIdp.com/saml",
+      cert: FAKE_CERT,
+      issuer: "onelogin_saml",
+      forceAuthn: false,
+      passive: true,
+    };
+
+    const result = {
+      "samlp:AuthnRequest": {
+        $: {
+          "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+          Version: "2.0",
+          ProtocolBinding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+          AssertionConsumerServiceURL: "http://localhost/saml/consume",
+          Destination: "https://wwwexampleIdp.com/saml",
+          IsPassive: "true",
         },
         "saml:Issuer": [
           { _: "onelogin_saml", $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" } },
@@ -169,146 +306,7 @@ describe("SAML request", function () {
       .then((doc) => {
         delete doc["samlp:AuthnRequest"]["$"]["ID"];
         delete doc["samlp:AuthnRequest"]["$"]["IssueInstant"];
-        expect(doc).to.equal(result);
-      });
-  });
-
-  it("Config with NameIDPolicy options", function () {
-    const config: SamlConfig = {
-      entryPoint: "https://wwwexampleIdp.com/saml",
-      cert: FAKE_CERT,
-      issuer: "onesaml_login",
-      identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-      allowCreate: false,
-      spNameQualifier: "https://exampleaffiliation.com/saml",
-    };
-
-    const result = {
-      "samlp:AuthnRequest": {
-        $: {
-          "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
-          Version: "2.0",
-          ProtocolBinding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-          AssertionConsumerServiceURL: "http://localhost/saml/consume",
-          Destination: "https://wwwexampleIdp.com/saml",
-        },
-        "saml:Issuer": [
-          { _: "onelogin_saml", $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" } },
-        ],
-        "samlp:NameIDPolicy": [
-          {
-            $: {
-              "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
-              Format: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-              AllowCreate: "false",
-              SPNameQualifier: "https://exampleaffiliation.com/saml",
-            },
-          },
-        ],
-        "samlp:RequestedAuthnContext": [
-          {
-            $: { "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol", Comparison: "exact" },
-            "saml:AuthnContextClassRef": [
-              {
-                _: "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
-                $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" },
-              },
-            ],
-          },
-        ],
-      },
-    };
-
-    const oSAML = new SAML(config);
-    oSAML
-      .getAuthorizeFormAsync("http://localhost/saml/consume")
-      .then((formBody) => {
-        expect(formBody).to.match(/<!DOCTYPE html>[^]*<input.*name="SAMLRequest"[^]*<\/html>/);
-        const samlRequestMatchValues = formBody.match(/<input.*name="SAMLRequest" value="([^"]*)"/);
-        assertRequired(samlRequestMatchValues?.[1]);
-        const encodedSamlRequest = samlRequestMatchValues?.[1];
-
-        let buffer = Buffer.from(encodedSamlRequest, "base64");
-        if (!config.skipRequestCompression) {
-          buffer = zlib.inflateRawSync(buffer);
-        }
-
-        return parseStringPromise(buffer.toString());
-      })
-      .then((doc) => {
-        delete doc["samlp:AuthnRequest"]["$"]["ID"];
-        delete doc["samlp:AuthnRequest"]["$"]["IssueInstant"];
-        expect(doc).to.equal(result);
-      });
-  });
-
-  it("Config with forceAuthn and passive", function () {
-    const config: SamlConfig = {
-      entryPoint: "https://wwwexampleIdp.com/saml",
-      cert: FAKE_CERT,
-      issuer: "onesaml_login",
-      forceAuthn: false,
-      passive: true,
-    };
-
-    const result = {
-      "samlp:AuthnRequest": {
-        $: {
-          "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
-          Version: "2.0",
-          ProtocolBinding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-          AssertionConsumerServiceURL: "http://localhost/saml/consume",
-          Destination: "https://wwwexampleIdp.com/saml",
-          ForceAuthn: false,
-          isPassive: true,
-        },
-        "saml:Issuer": [
-          { _: "onelogin_saml", $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" } },
-        ],
-        "samlp:NameIDPolicy": [
-          {
-            $: {
-              "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
-              Format: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-              AllowCreate: "false",
-              SPNameQualifier: "https://exampleaffiliation.com/saml",
-            },
-          },
-        ],
-        "samlp:RequestedAuthnContext": [
-          {
-            $: { "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol", Comparison: "exact" },
-            "saml:AuthnContextClassRef": [
-              {
-                _: "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
-                $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" },
-              },
-            ],
-          },
-        ],
-      },
-    };
-
-    const oSAML = new SAML(config);
-    oSAML
-      .getAuthorizeFormAsync("http://localhost/saml/consume")
-      .then((formBody) => {
-        expect(formBody).to.match(/<!DOCTYPE html>[^]*<input.*name="SAMLRequest"[^]*<\/html>/);
-        const samlRequestMatchValues = formBody.match(/<input.*name="SAMLRequest" value="([^"]*)"/);
-        assertRequired(samlRequestMatchValues?.[1]);
-        const encodedSamlRequest = samlRequestMatchValues?.[1];
-
-        let buffer = Buffer.from(encodedSamlRequest, "base64");
-        if (!config.skipRequestCompression) {
-          buffer = zlib.inflateRawSync(buffer);
-        }
-
-        return parseStringPromise(buffer.toString());
-      })
-      .then((doc) => {
-        delete doc["samlp:AuthnRequest"]["$"]["ID"];
-        delete doc["samlp:AuthnRequest"]["$"]["IssueInstant"];
-        expect(doc).to.equal(result);
+        expect(doc).to.deep.equal(result);
       });
   });
 


### PR DESCRIPTION
# Description

Several tests in `samlRequets.spec.ts` were not executing properly because they were `async` tests, but not marked as such. This corrects that and fixes the broken tests.