### PR TITLE
Make Issuer Required in the Types Too (like it is at runtime)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export type CertCallback = (
  */
 export interface MandatorySamlOptions {
   cert: string | string[] | CertCallback;
+  issuer: string;
 }
 
 export interface SamlIDPListConfig {
@@ -102,7 +103,6 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
   protocol?: string;
   host: string;
   entryPoint?: string;
-  issuer: string;
   decryptionPvk?: string | Buffer;
 
   // Additional SAML behaviors

--- a/test/crypto.spec.ts
+++ b/test/crypto.spec.ts
@@ -4,7 +4,6 @@ import * as assert from "assert";
 import { certToPEM, generateUniqueId, keyToPEM } from "../src/crypto";
 import { TEST_CERT } from "./types";
 import { assertRequired } from "../src/utility";
-import { SamlConfig } from "../src/types";
 
 describe("crypto.ts", function () {
   describe("keyToPEM", function () {
@@ -44,12 +43,8 @@ describe("crypto.ts", function () {
 
   describe("certToPEM", function () {
     it("should generate valid certificate", function () {
-      const samlConfig: SamlConfig = {
-        entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-        cert: "-----BEGIN CERTIFICATE-----" + TEST_CERT + "-----END CERTIFICATE-----",
-        acceptedClockSkewMs: -1,
-      };
-      const certificate = certToPEM(samlConfig.cert.toString());
+      const cert = "-----BEGIN CERTIFICATE-----" + TEST_CERT + "-----END CERTIFICATE-----";
+      const certificate = certToPEM(cert.toString());
       const certificateBegin = certificate.match(/BEGIN/g);
       const certificateEnd = certificate.match(/END/g);
       assertRequired(certificateBegin, "certificate does not have a BEGIN block");

--- a/test/test-signatures.spec.ts
+++ b/test/test-signatures.spec.ts
@@ -18,10 +18,10 @@ describe("Signatures", function () {
       samlResponseBody: Record<string, string>,
       shouldErrorWith: string | false | undefined,
       amountOfSignatureChecks = 1,
-      options: Partial<SamlConfig> = { issuer: "onesaml_login" }
+      options: Partial<SamlConfig> = {}
     ) => {
       //== Instantiate new instance before every test
-      const samlObj = new SAML({ cert, ...options });
+      const samlObj = new SAML({ cert, issuer: options.issuer ?? "onesaml_login", ...options });
       //== Spy on `validateSignature` to be able to count how many times it has been called
       const validateSignatureSpy = sinon.spy(samlObj, "validateSignature");
 


### PR DESCRIPTION
# Description

Resolves #89 

We had an application using the [4.0.0-beta.2](https://www.npmjs.com/package/node-saml/v/4.0.0-beta.2) version that we needed to update to use the latest master commit instead to pick up the update to the xml-encryption dependency that patched a security vulnerability. 

That app was not previously passing a value for "issuer" to the SAML constructor, but was relying on the library to provide a default.

After updating, this caused problems similar to the ones mentioned in the Github issue, and after rolling back and trying again, we patched this by providing a value for "issuer" to fit the new requirement.

We noted this could've been caught earlier had TS warned us about the new requirement, and so wanted to try and update the library to that effect for anyone else who might come across this change in the future.

# Checklist:

- Issue Addressed: 89 
- Link to SAML spec: N/A
- Tests included? Updated existing ones
- Documentation updated? 
    - The READme only seems to have examples where issuer is set. I'm not sure exactly where this would make sense to mention
