### PR TITLE
Reduce frequency of dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,11 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     # Always increase the version requirement
     # to match the new version.
     versioning-strategy: increase
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Dependabot can get a little noisy with its notifications about updates. Reduce the frequency while still retaining information about everything that needs updating and the convenient PR that is ready-to-go.

See https://github.com/node-saml/node-saml/pull/150#issuecomment-1216795167
