### PR TITLE
feat: expose getLogoutResponseUrlAsync publicly

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -620,7 +620,7 @@ class SAML {
     )(callback);
   }
 
-  protected async getLogoutResponseUrlAsync(
+  async getLogoutResponseUrlAsync(
     samlLogoutRequest: Profile,
     RelayState: string,
     options: AuthenticateOptions & AuthorizeOptions,

--- a/test/samlTests.spec.ts
+++ b/test/samlTests.spec.ts
@@ -1,4 +1,5 @@
 "use strict";
+import * as sinon from "sinon";
 import { URL } from "url";
 import { expect } from "chai";
 import * as assert from "assert";
@@ -18,6 +19,7 @@ describe("SAML.js", function () {
         logoutUrl: "https://exampleidp.com/path?key=value",
         cert: FAKE_CERT,
         issuer: "onesaml_login",
+        generateUniqueId: () => "uniqueId",
       });
       req = {
         protocol: "https",
@@ -186,6 +188,32 @@ describe("SAML.js", function () {
             assertRequired(target);
             const parsed = new URL(target);
             expect(parsed.searchParams.get("SAMLResponse")).to.not.be.empty;
+            done();
+          } catch (err2) {
+            done(err2);
+          }
+        });
+      });
+    });
+
+    describe("getLogoutResponseUrlAsync", function () {
+      let fakeClock: sinon.SinonFakeTimers;
+
+      beforeEach(function () {
+        fakeClock = sinon.useFakeTimers(Date.parse("2020-09-25T16:59:00Z"));
+      });
+
+      afterEach(function () {
+        fakeClock.restore();
+      });
+
+      it("resolves with the same target as getLogoutResponseUrl", function (done) {
+        saml.getLogoutResponseUrl(req.samlLogoutRequest, "", {}, true, async function (err, cbTarget) {
+          try {
+            const asyncTarget = await saml.getLogoutResponseUrlAsync(req.samlLogoutRequest, "", {}, true);
+            assertRequired(cbTarget);
+            assertRequired(asyncTarget);
+            assert.strictEqual(asyncTarget, cbTarget);
             done();
           } catch (err2) {
             done(err2);

--- a/test/samlTests.spec.ts
+++ b/test/samlTests.spec.ts
@@ -208,17 +208,28 @@ describe("SAML.js", function () {
       });
 
       it("resolves with the same target as getLogoutResponseUrl", function (done) {
-        saml.getLogoutResponseUrl(req.samlLogoutRequest, "", {}, true, async function (err, cbTarget) {
-          try {
-            const asyncTarget = await saml.getLogoutResponseUrlAsync(req.samlLogoutRequest, "", {}, true);
-            assertRequired(cbTarget);
-            assertRequired(asyncTarget);
-            assert.strictEqual(asyncTarget, cbTarget);
-            done();
-          } catch (err2) {
-            done(err2);
+        saml.getLogoutResponseUrl(
+          req.samlLogoutRequest,
+          "",
+          {},
+          true,
+          async function (err, cbTarget) {
+            try {
+              const asyncTarget = await saml.getLogoutResponseUrlAsync(
+                req.samlLogoutRequest,
+                "",
+                {},
+                true
+              );
+              assertRequired(cbTarget);
+              assertRequired(asyncTarget);
+              assert.strictEqual(asyncTarget, cbTarget);
+              done();
+            } catch (err2) {
+              done(err2);
+            }
           }
-        });
+        );
       });
     });
   });


### PR DESCRIPTION
# Description

Expose getLogoutResponseUrlAsync publicly.
Fixes #193.
I have duplicated the tests from the callback version with the necessary changes for async, I'm not sure whether you want to factor those tests.

# Checklist:

- Issue Addressed: [X]
- Link to SAML spec: [ ]
- Tests included? [X]
- Documentation updated? [ ]
