### PR TITLE
Throw if multiple XML roots detected

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -677,6 +677,14 @@ class SAML {
       if (!Object.prototype.hasOwnProperty.call(doc, "documentElement"))
         throw new Error("SAMLResponse is not valid base64-encoded XML");
 
+      if (
+        Array.from(doc.childNodes as NodeListOf<Element>).filter(
+          (n) => n.tagName != null && n.childNodes != null
+        ).length !== 1
+      ) {
+        throw new Error("Malformed XML; multiple roots detected");
+      }
+
       const inResponseToNodes = xpath.selectAttributes(
         doc,
         "/*[local-name()='Response']/@InResponseTo"
@@ -690,12 +698,7 @@ class SAML {
       const certs = await this.certsToCheck();
       // Check if this document has a valid top-level signature which applies to the entire XML document
       let validSignature = false;
-      if (
-        validateSignature(xml, doc.documentElement, certs) &&
-        Array.from(doc.childNodes as NodeListOf<Element>).filter(
-          (n) => n.tagName != null && n.childNodes != null
-        ).length === 1
-      ) {
+      if (validateSignature(xml, doc.documentElement, certs)) {
         validSignature = true;
       }
 

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -186,7 +186,7 @@ export const signXml = (
 export const parseDomFromString = (xml: string): Promise<Document> => {
   return new Promise(function (resolve, reject) {
     function errHandler(msg: string) {
-      reject(new Error(msg));
+      return reject(new Error(msg));
     }
 
     const dom = new xmldom.DOMParser({
@@ -206,7 +206,7 @@ export const parseDomFromString = (xml: string): Promise<Document> => {
     }).parseFromString(xml, "text/xml");
 
     if (!Object.prototype.hasOwnProperty.call(dom, "documentElement")) {
-      reject(new Error("Not a valid XML document"));
+      return reject(new Error("Not a valid XML document"));
     }
 
     if (
@@ -214,10 +214,10 @@ export const parseDomFromString = (xml: string): Promise<Document> => {
         (n) => n.tagName != null && n.childNodes != null
       ).length !== 1
     ) {
-      reject(new Error("Malformed XML; multiple roots detected"));
+      return reject(new Error("Malformed XML; multiple roots detected"));
     }
 
-    resolve(dom);
+    return resolve(dom);
   });
 };
 

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -183,8 +183,42 @@ export const signXml = (
   return sig.getSignedXml();
 };
 
-export const parseDomFromString = (xml: string): Document => {
-  return new xmldom.DOMParser().parseFromString(xml);
+export const parseDomFromString = (xml: string): Promise<Document> => {
+  return new Promise(function (resolve, reject) {
+    function errHandler(msg: string) {
+      reject(new Error(msg));
+    }
+
+    const dom = new xmldom.DOMParser({
+      /**
+       * locator is always need for error position info
+       */
+      locator: {},
+      /**
+       * you can override the errorHandler for xml parser
+       * @link http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
+       */
+      errorHandler: {
+        warning: console.warn,
+        error: errHandler,
+        fatalError: errHandler,
+      },
+    }).parseFromString(xml, "text/xml");
+
+    if (!Object.prototype.hasOwnProperty.call(dom, "documentElement")) {
+      reject(new Error("Not a valid XML document"));
+    }
+
+    if (
+      Array.from(dom.childNodes as NodeListOf<Element>).filter(
+        (n) => n.tagName != null && n.childNodes != null
+      ).length !== 1
+    ) {
+      reject(new Error("Malformed XML; multiple roots detected"));
+    }
+
+    resolve(dom);
+  });
 };
 
 export const parseXml2JsFromString = async (xml: string | Buffer): Promise<XMLOutput> => {
@@ -254,7 +288,7 @@ export const getNameIdAsync = async (
     const encryptedDataXml = encryptedDatas[0].toString();
 
     const decryptedXml = await decryptXml(encryptedDataXml, decryptionPvk);
-    const decryptedDoc = parseDomFromString(decryptedXml);
+    const decryptedDoc = await parseDomFromString(decryptedXml);
     const decryptedIds = xpath.selectElements(decryptedDoc, "/*[local-name()='NameID']");
     if (decryptedIds.length !== 1) {
       throw new Error("Invalid EncryptedAssertion content");

--- a/test/test-signatures.spec.ts
+++ b/test/test-signatures.spec.ts
@@ -10,6 +10,7 @@ const cert = fs.readFileSync(__dirname + "/static/cert.pem", "ascii");
 
 describe("Signatures", function () {
   const INVALID_SIGNATURE = "Invalid signature";
+  const INVALID_DOCUMENT = "Malformed XML; multiple roots detected";
   const INVALID_DOCUMENT_SIGNATURE = "Invalid document signature";
   const INVALID_ENCRYPTED_SIGNATURE = "Invalid signature from encrypted assertion";
   const INVALID_TOO_MANY_TRANSFORMS = "Invalid signature, too many transforms";
@@ -72,8 +73,8 @@ describe("Signatures", function () {
       "multiple roots => invalid",
       testOneResponse(
         "/invalid/response.root-signed.multiple-root-elements.xml",
-        INVALID_DOCUMENT_SIGNATURE,
-        1
+        INVALID_DOCUMENT,
+        0
       )
     );
   });


### PR DESCRIPTION
# Description

Based on the discussion at #191, it seems there is a better way to protect against XML files with multiple roots. This PR is to implement that.