### PR TITLE
Bump @xmldom/xmldom from 0.7.5 to 0.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8970,9 +8970,9 @@
       },
       "dependencies": {
         "@xmldom/xmldom": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
-          "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A=="
+          "version": "0.7.6",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
+          "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ=="
         }
       }
     },
@@ -8987,9 +8987,9 @@
       },
       "dependencies": {
         "@xmldom/xmldom": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
-          "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A=="
+          "version": "0.7.6",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
+          "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ=="
         }
       }
     },


### PR DESCRIPTION
# Description

Similar to #188 , but this update was done by `npm audit` to catch some stuff in the lockfile.