### PR TITLE
Fixes #208, updated readme by updating package names.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -25,7 +25,7 @@ that you found no references in the spec concerning your issue.
 
 ** Community development model **
 
-node-saml is maintained by a number of current users. There is no author or primary maintainer
+@node-saml/node-saml is maintained by a number of current users. There is no author or primary maintainer
 waiting to write your tests and documentation for you. To increase the odds that your issue
 is promptly dealt with, consider a pull request to address the issue that includes test coverage
 and updated documentation.
@@ -40,4 +40,4 @@ A clear and concise description of what you expected to happen.
 **Environment**
 
 - Node.js version:
-- node-saml version:
+- @node-saml/node-saml version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -25,7 +25,7 @@ that you found no references in the spec concerning your issue.
 
 ** Community development model **
 
-node-saml is maintained by a number of current users. There is no author or primary maintainer
+@node-saml/node-saml is maintained by a number of current users. There is no author or primary maintainer
 waiting to write your tests and documentation for you. To increase the odds that your issue
 is promptly dealt with, consider a pull request to address the issue that includes test coverage
 and updated documentation.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@
 
 [![NPM](https://nodei.co/npm/@node-saml/node-saml.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/@node-saml/node-saml)
 
-This is a [SAML 2.0](http://en.wikipedia.org/wiki/SAML_2.0) authentication provider for Node.js. This was forked from `passport-saml` at v3.0.0 and will become the SAML implementation for `passport-saml`. When this is mature, `passport-saml` will have code removed and replaced by a dependency on this library.
-
-The code was originally based on Michael Bosworth's [express-saml](https://github.com/bozzltron/express-saml) library.
+This is a [SAML 2.0](http://en.wikipedia.org/wiki/SAML_2.0) authentication provider for Node.js.
 
 ## Installation
 
@@ -20,7 +18,7 @@ For now
 
 Once the first release is done, this will be available at
 
-    $ npm install node-saml
+    $ npm install @node-saml/node-saml
 
 ## Usage
 
@@ -31,7 +29,7 @@ The examples utilize the [Feide OpenIdp identity provider](https://openidp.feide
 The SAML identity provider will redirect you to the URL provided by the `path` configuration.
 
 ```javascript
-const { SAML } = require("node-saml");
+const { SAML } = require("@node-saml/node-saml");
 
 const options = {};
 const saml = new SAML(options);


### PR DESCRIPTION
Changed `node-saml` --> `@node-saml/node-saml` and `passport-saml` --> `@node-saml/passport-saml` to enforce current main packages. (even though actual fork may have happened from "passport-saml" --> "node-saml".)

Did not change `Node SAML` texts, because those are not directly refering to package name.