### PR TITLE
Lock to TypeScript <4.9.0 due to a regression in 4.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "release-it": "^15.5.0",
     "sinon": "^14.0.1",
     "ts-node": "^10.9.1",
-    "typescript": "^4.8.4"
+    "typescript": ">=4.0.0 <4.9.0"
   },
   "engines": {
     "node": ">= 14"


### PR DESCRIPTION
# Description

There are several reported regressions with TypeScript 4.9, specifically 4.9.3, one of which [affects `node-saml`](https://github.com/node-saml/node-saml/issues/218). This PR will prevent us taking that version of TypeScript.