### PR TITLE
Expose ValidateInResponseTo as it is required in options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   Profile,
   SamlConfig,
   SamlOptions,
+  ValidateInResponseTo,
 } from "./types";
 
-export { SAML, CacheItem, CacheProvider, SamlOptions, MandatorySamlOptions, Profile, SamlConfig };
+export { SAML, CacheItem, CacheProvider, SamlOptions, MandatorySamlOptions, Profile, SamlConfig, ValidateInResponseTo };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,13 @@ import {
   ValidateInResponseTo,
 } from "./types";
 
-export { SAML, CacheItem, CacheProvider, SamlOptions, MandatorySamlOptions, Profile, SamlConfig, ValidateInResponseTo };
+export {
+  SAML,
+  CacheItem,
+  CacheProvider,
+  SamlOptions,
+  MandatorySamlOptions,
+  Profile,
+  SamlConfig,
+  ValidateInResponseTo,
+};


### PR DESCRIPTION
# Description

Options required by `passport-saml` when creating a new configuration require the property `validateInResponseTo` to use the enum `ValidateInResponseTo`. But this enum is not easily accessible in `@node-saml/passport-saml`.

In typescript, we need to import `@node-saml/node-saml/lib/types` to use this enum, which requires to add the dependency to `@node-saml/node-saml` to a project that would only require `@node-saml/passport-saml`.

By exposing this enum in `node-saml`, it'll be also exposed by `passport-saml` once updated to the latest version of its dependency.

# Checklist:

- Issue Addressed: [ ]
- Link to SAML spec: [ ]
- Tests included? [ ]
- Documentation updated? [ ]
