### PR TITLE
Allow to configure optional logger function to log SAML requests/resp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ const saml = new SAML(options);
 - `generateUniqueId`: optional function which will be called to generate unique IDs for SAML requests.
 - `scoping`: An optional configuration which implements the functionality [explained in the SAML spec paragraph "3.4.1.2 Element <Scoping>"](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf). The config object is structured as following:
 - `signMetadata`: if true, adds a signature to the generated Service Provider metadata. `privateKey` must be set to use this option.
+- `log`: optional logger function to log SAML request and response.
 
 ```javascript
 {

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -122,6 +122,7 @@ class SAML {
       generateUniqueId: ctorOptions.generateUniqueId ?? generateUniqueId,
       signMetadata: ctorOptions.signMetadata ?? false,
       racComparison: ctorOptions.racComparison ?? "exact",
+      log: ctorOptions.log || undefined
     };
 
     /**
@@ -328,6 +329,11 @@ class SAML {
     if (isHttpPostBinding && isValidSamlSigningOptions(this.options)) {
       stringRequest = signAuthnRequestPost(stringRequest, this.options);
     }
+
+    if (this.options.log) {
+      this.options.log.info("SAML authorization request: '%s'", stringRequest);
+    }
+
     return stringRequest;
   }
 
@@ -384,7 +390,13 @@ class SAML {
     }
 
     await this.cacheProvider.saveAsync(id, instant);
-    return buildXmlBuilderObject(request, false);
+    const stringRequest = buildXmlBuilderObject(request, false);
+
+    if (this.options.log) {
+      this.options.log.info("SAML logout request: '%s'", stringRequest);
+    }
+
+    return stringRequest;
   }
 
   _generateLogoutResponse(this: SAML, logoutRequest: Profile, success: boolean): string {
@@ -422,7 +434,13 @@ class SAML {
       },
     };
 
-    return buildXmlBuilderObject(request, false);
+    const stringLogoutResponse = buildXmlBuilderObject(request, false);
+
+    if (this.options.log) {
+      this.options.log.info("SAML logout response: '%s'", stringLogoutResponse);
+    }
+
+    return stringLogoutResponse;
   }
 
   async _requestToUrlAsync(
@@ -673,6 +691,11 @@ class SAML {
 
     try {
       xml = Buffer.from(container.SAMLResponse, "base64").toString("utf8");
+
+      if (this.options.log) {
+        this.options.log.info("SAML authorization response: '%s'", xml);
+      }
+
       doc = await parseDomFromString(xml);
 
       const inResponseToNodes = xpath.selectAttributes(

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,6 +202,9 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
       "#text": string;
     }[];
   };
+
+  // logger function
+  log?: any;
 }
 
 export interface GenerateServiceProviderMetadataParams {
@@ -226,6 +229,7 @@ export interface GenerateServiceProviderMetadataParams {
 export interface StrategyOptions {
   name?: string;
   passReqToCallback?: boolean;
+  log?: any;
 }
 
 /**

--- a/test/samlTests.spec.ts
+++ b/test/samlTests.spec.ts
@@ -77,8 +77,7 @@ describe("SAML.js", function () {
       it("verify call with log function", async () => {
         const target = await saml.getAuthorizeUrlAsync("", req.headers.host, {});
         expect(new URL(target).searchParams.get("SAMLRequest")).to.not.be.empty;
-        // verify stub is actually called
-        saml.options.log.info.calledOnce;
+        sinon.assert.calledOnce(saml.options.log.info)
       });
     });
 
@@ -123,8 +122,7 @@ describe("SAML.js", function () {
         assertRequired(req.user);
         const target = await saml.getLogoutUrlAsync(req.user, "", {});
         expect(new URL(target).searchParams.get("SAMLRequest")).to.not.be.empty;
-        // verify stub is actually called
-        saml.options.log.info.calledOnce;
+        sinon.assert.calledOnce(saml.options.log.info);
       });
     });
 
@@ -136,6 +134,7 @@ describe("SAML.js", function () {
             assertRequired(target);
             const parsed = new URL(target);
             assert.strictEqual(parsed.host, "exampleidp.com");
+            sinon.assert.calledOnce(saml.options.log.info);
             done();
           } catch (err2) {
             done(err2);
@@ -149,6 +148,7 @@ describe("SAML.js", function () {
             assertRequired(target);
             const parsed = new URL(target);
             assert.strictEqual(parsed.protocol, "https:");
+            sinon.assert.calledOnce(saml.options.log.info);
             done();
           } catch (err2) {
             done(err2);
@@ -162,6 +162,7 @@ describe("SAML.js", function () {
             assertRequired(target);
             const parsed = new URL(target);
             assert.strictEqual(parsed.pathname, "/path");
+            sinon.assert.calledOnce(saml.options.log.info);
             done();
           } catch (err2) {
             done(err2);
@@ -175,6 +176,7 @@ describe("SAML.js", function () {
             assertRequired(target);
             const parsed = new URL(target);
             assert.strictEqual(parsed.searchParams.get("key"), "value");
+            sinon.assert.calledOnce(saml.options.log.info);
             done();
           } catch (err2) {
             done(err2);
@@ -190,6 +192,7 @@ describe("SAML.js", function () {
             assert.strictEqual(parsed.searchParams.get("key"), "value");
             expect(parsed.searchParams.get("SAMLResponse")).to.exist;
             assert.strictEqual(parsed.searchParams.get("additionalKey"), "additionalValue");
+            sinon.assert.calledOnce(saml.options.log.info);
             done();
           } catch (err2) {
             done(err2);
@@ -204,6 +207,7 @@ describe("SAML.js", function () {
             assertRequired(target);
             const parsed = new URL(target);
             expect(parsed.searchParams.get("SAMLResponse")).to.not.be.empty;
+            sinon.assert.calledOnce(saml.options.log.info);
             done();
           } catch (err2) {
             done(err2);
@@ -240,8 +244,7 @@ describe("SAML.js", function () {
               assertRequired(cbTarget);
               assertRequired(asyncTarget);
               assert.strictEqual(asyncTarget, cbTarget);
-              // verify stub call
-              saml.options.log.info.calledOnce;
+              sinon.assert.calledTwice(saml.options.log.info);
               done();
             } catch (err2) {
               done(err2);

--- a/test/samlTests.spec.ts
+++ b/test/samlTests.spec.ts
@@ -20,6 +20,9 @@ describe("SAML.js", function () {
         cert: FAKE_CERT,
         issuer: "onesaml_login",
         generateUniqueId: () => "uniqueId",
+        log: {
+          info: sinon.stub()
+        }
       });
       req = {
         protocol: "https",
@@ -71,6 +74,12 @@ describe("SAML.js", function () {
         const target = await saml.getAuthorizeUrlAsync("", req.headers.host, {});
         expect(new URL(target).searchParams.get("SAMLRequest")).to.not.be.empty;
       });
+      it("verify call with log function", async () => {
+        const target = await saml.getAuthorizeUrlAsync("", req.headers.host, {});
+        expect(new URL(target).searchParams.get("SAMLRequest")).to.not.be.empty;
+        // verify stub is actually called
+        saml.options.log.info.calledOnce;
+      });
     });
 
     describe("getLogoutUrl", function () {
@@ -109,6 +118,13 @@ describe("SAML.js", function () {
         assertRequired(req.user);
         const target = await saml.getLogoutUrlAsync(req.user, "", {});
         expect(new URL(target).searchParams.get("SAMLRequest")).to.not.be.empty;
+      });
+      it("verify call with log function", async () => {
+        assertRequired(req.user);
+        const target = await saml.getLogoutUrlAsync(req.user, "", {});
+        expect(new URL(target).searchParams.get("SAMLRequest")).to.not.be.empty;
+        // verify stub is actually called
+        saml.options.log.info.calledOnce;
       });
     });
 
@@ -224,6 +240,8 @@ describe("SAML.js", function () {
               assertRequired(cbTarget);
               assertRequired(asyncTarget);
               assert.strictEqual(asyncTarget, cbTarget);
+              // verify stub call
+              saml.options.log.info.calledOnce;
               done();
             } catch (err2) {
               done(err2);


### PR DESCRIPTION
# Allow to configure optional logger function to log SAML operations

We have migrated our application's Login component away from Java/Spring to Typescript with `passport-saml`.

One facet of the Spring SAML libraries which we found very useful when debugging SAML config issues in production was the ability to configure the library to ouput logs for key SAML operations. [This was introduced in](https://github.com/spring-attic/spring-security-saml/issues/63) with a comment in the Spring code that said "[Implementations are supposed to log significant SAML operations](https://github.com/spring-attic/spring-security-saml/blob/main/core/src/main/java/org/springframework/security/saml/log/SAMLLogger.java#L22)."

We have been unable to find a reference to this "supposed to" in the formal SAML specifications, but as mentioned it has been a very useful capability in the past, so we thought to propose this approach as a way to address the issue described in https://github.com/node-saml/passport-saml/issues/279.

# Checklist:

- Issue Addressed: [node-saml/passport-saml/issues/279]
- Link to SAML spec: [ ]
- Tests included? [Yes]
- Documentation updated? [Yes]
