### PR TITLE
feat: support additionalParams on HTTP-POST binding

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -517,7 +517,8 @@ class SAML {
 
   async getAuthorizeMessageAsync(
     RelayState: string,
-    host?: string
+    host?: string,
+    options?: AuthorizeOptions
   ): Promise<querystring.ParsedUrlQueryInput> {
     assertRequired(this.options.entryPoint, "entryPoint is required");
 
@@ -530,7 +531,8 @@ class SAML {
     }
 
     const operation = "authorize";
-    const additionalParameters = this._getAdditionalParams(RelayState, operation);
+    const overrideParams = options ? options.additionalParams || {} : {};
+    const additionalParameters = this._getAdditionalParams(RelayState, operation, overrideParams);
     const samlMessage: querystring.ParsedUrlQueryInput = {
       SAMLRequest: buffer.toString("base64"),
     };
@@ -542,7 +544,11 @@ class SAML {
     return samlMessage;
   }
 
-  async getAuthorizeFormAsync(RelayState: string, host?: string): Promise<string> {
+  async getAuthorizeFormAsync(
+    RelayState: string,
+    host?: string,
+    options?: AuthorizeOptions
+  ): Promise<string> {
     assertRequired(this.options.entryPoint, "entryPoint is required");
 
     // The quoteattr() function is used in a context, where the result will not be evaluated by javascript
@@ -575,7 +581,7 @@ class SAML {
       );
     };
 
-    const samlMessage = await this.getAuthorizeMessageAsync(RelayState, host);
+    const samlMessage = await this.getAuthorizeMessageAsync(RelayState, host, options);
 
     const formInputs = Object.keys(samlMessage)
       .map((k) => {

--- a/test/samlRequest.spec.ts
+++ b/test/samlRequest.spec.ts
@@ -399,6 +399,49 @@ describe("SAML request", function () {
     });
   });
 
+  describe("With additional run-time parameters", function () {
+    const config: SamlConfig = {
+      entryPoint: "https://wwwexampleIdp.com/saml",
+      cert: FAKE_CERT,
+      issuer: "onelogin_saml",
+    };
+
+    const oSAML = new SAML(config);
+
+    it("getAuthorizeMessageAsync", async function () {
+      const samlMessage = await oSAML.getAuthorizeMessageAsync(
+        "http://localhost/saml/consume",
+        undefined,
+        { additionalParams: { foo: "bar" } }
+      );
+
+      assertRequired(samlMessage.SAMLRequest);
+      expect(samlMessage.foo).to.equal("bar");
+    });
+
+    it("getAuthorizeFormAsync", async function () {
+      const formBody = await oSAML.getAuthorizeFormAsync(
+        "http://localhost/saml/consume",
+        undefined,
+        { additionalParams: { foo: "bar" } }
+      );
+
+      expect(formBody).to.match(/<!DOCTYPE html>[^]*<input.*name="SAMLRequest"[^]*<\/html>/);
+      expect(formBody).to.match(/<input.*name="foo" value="bar"/);
+    });
+
+    it("getAuthorizeFormAsync with empty options", async function () {
+      const formBody = await oSAML.getAuthorizeFormAsync(
+        "http://localhost/saml/consume",
+        undefined,
+        {}
+      );
+
+      expect(formBody).to.match(/<!DOCTYPE html>[^]*<input.*name="SAMLRequest"[^]*<\/html>/);
+      expect(formBody).to.not.match(/<input.*name="foo" value="bar"/);
+    });
+  });
+
   describe("Config with disableRequestedAuthnContext, skipRequestCompression, disableRequestAcsUrl", function () {
     const config: SamlConfig = {
       entryPoint: "https://wwwexampleIdp.com/saml",


### PR DESCRIPTION
# Description

This allows consumers of the library to include the `additionalParams` in options when working with `getAuthorizeFormAsync` like you can also do with `getAuthorizeUrlAsync`. It would, for example, allow overriding RelayState in `passport-saml` or adding any arbitrary additional parameters your SAML integration may require.

# Checklist:

- Issue Addressed: [x]
- Link to SAML spec: [N/A]
- Tests included? [x]
- Documentation updated? [N/A (I think?)]
