### PR TITLE
Acknowledge that XML can be parsed to `any`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export type XMLObject = {
 
 export type XMLInput = XMLObject;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type XMLOutput = Record<string, any>;
 
 export type AuthorizeRequestXML = {


### PR DESCRIPTION
# Description

Get rid of an eslint message about how we shouldn't be using `any` for types. This would be very cumbersome to get rid of because it is a result of parsing XML. We'd have to have a specific type of each kind of XML that we'd expect, and there isn't really a need to create a type for the entire SAML spec. Instead, we can rely on tests to make sure that we're doing the right thing.