### PR TITLE
Prefer Chai `expect` to Node `assert`

### DIFF
--- a/test/crypto.spec.ts
+++ b/test/crypto.spec.ts
@@ -1,6 +1,5 @@
 import * as fs from "fs";
 import { expect } from "chai";
-import * as assert from "assert";
 import { keyInfoToPem, generateUniqueId, stripPemHeaderAndFooter } from "../src/crypto";
 import {
   TEST_CERT_SINGLELINE,
@@ -27,48 +26,50 @@ describe("crypto.ts", function () {
 
     describe("invalid values", function () {
       it("should throw with null", function () {
-        assert.throws(() => keyInfoToPem(null as never, "CERTIFICATE"));
+        expect(() => keyInfoToPem(null as never, "CERTIFICATE")).to.throw();
       });
 
       it("should throw with false", function () {
-        assert.throws(() => keyInfoToPem(false as never, "CERTIFICATE"));
+        expect(() => keyInfoToPem(false as never, "CERTIFICATE")).to.throw();
       });
 
       it("should throw with empty string", function () {
-        assert.throws(() => keyInfoToPem("", "CERTIFICATE"));
+        expect(() => keyInfoToPem("", "CERTIFICATE")).to.throw();
       });
 
       it("should throw with empty Buffer", function () {
-        assert.throws(() => keyInfoToPem(Buffer.from(""), "CERTIFICATE"));
+        expect(() => keyInfoToPem(Buffer.from(""), "CERTIFICATE")).to.throw();
       });
 
       it("should throw if string is not in PEM format or not in Base64 format", function () {
-        assert.throws(() => keyInfoToPem("I'm not pem file", "CERTIFICATE"));
+        expect(() => keyInfoToPem("I'm not pem file", "CERTIFICATE")).to.throw();
       });
 
       it("should throw if cert is missing newlines after header and before footer", function () {
-        assert.throws(() =>
+        expect(() =>
           keyInfoToPem(
             `-----BEGIN CERTIFICATE-----${TEST_CERT_MULTILINE.trim()}-----END CERTIFICATE-----`,
             "CERTIFICATE"
           )
-        );
+        ).to.throw();
       });
+
       it("should throw if cert is missing newline after header ", function () {
-        assert.throws(() =>
+        expect(() =>
           keyInfoToPem(
             `-----BEGIN CERTIFICATE-----${TEST_CERT_MULTILINE}\n-----END CERTIFICATE-----`,
             "CERTIFICATE"
           )
-        );
+        ).to.throw();
       });
+
       it("should throw if cert is missing newline before footer ", function () {
-        assert.throws(() =>
+        expect(() =>
           keyInfoToPem(
             `-----BEGIN CERTIFICATE-----\n${TEST_CERT_MULTILINE}-----END CERTIFICATE-----`,
             "CERTIFICATE"
           )
-        );
+        ).to.throw();
       });
     });
 

--- a/test/samlTests.spec.ts
+++ b/test/samlTests.spec.ts
@@ -318,7 +318,7 @@ describe("saml.ts", function () {
           try {
             assertRequired(target);
             const parsed = new URL(target);
-            assert.strictEqual(parsed.host, "exampleidp.com");
+            expect(parsed.host).to.equal("exampleidp.com");
             done();
           } catch (err2) {
             done(err2);
@@ -332,7 +332,7 @@ describe("saml.ts", function () {
           try {
             assertRequired(target);
             const parsed = new URL(target);
-            assert.strictEqual(parsed.protocol, "https:");
+            expect(parsed.protocol).to.equal("https:");
             done();
           } catch (err2) {
             done(err2);
@@ -346,7 +346,7 @@ describe("saml.ts", function () {
           try {
             assertRequired(target);
             const parsed = new URL(target);
-            assert.strictEqual(parsed.pathname, "/path");
+            expect(parsed.pathname).to.equal("/path");
             done();
           } catch (err2) {
             done(err2);
@@ -360,7 +360,7 @@ describe("saml.ts", function () {
           try {
             assertRequired(target);
             const parsed = new URL(target);
-            assert.strictEqual(parsed.searchParams.get("key"), "value");
+            expect(parsed.searchParams.get("key")).to.equal("value");
             done();
           } catch (err2) {
             done(err2);
@@ -374,9 +374,9 @@ describe("saml.ts", function () {
           try {
             assertRequired(target);
             const parsed = new URL(target);
-            assert.strictEqual(parsed.searchParams.get("key"), "value");
+            expect(parsed.searchParams.get("key")).to.equal("value");
             expect(parsed.searchParams.get("SAMLResponse")).to.exist;
-            assert.strictEqual(parsed.searchParams.get("additionalKey"), "additionalValue");
+            expect(parsed.searchParams.get("additionalKey")).to.equal("additionalValue");
             done();
           } catch (err2) {
             done(err2);
@@ -427,7 +427,7 @@ describe("saml.ts", function () {
               );
               assertRequired(cbTarget);
               assertRequired(asyncTarget);
-              assert.strictEqual(asyncTarget, cbTarget);
+              expect(asyncTarget).to.equal(cbTarget);
               done();
             } catch (err2) {
               done(err2);

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -1021,7 +1021,7 @@ describe("node-saml /", function () {
                 message: "InResponseTo is not valid",
               });
 
-              assert.strictEqual(await samlObj.cacheProvider.getAsync(requestId), null);
+              expect(await samlObj.cacheProvider.getAsync(requestId)).to.be.null;
             });
           });
         }
@@ -1893,17 +1893,14 @@ describe("node-saml /", function () {
       });
 
       it("should check the value of the option `racComparison`", function () {
-        assert.throws(
-          () => {
-            new SAML({
-              callbackUrl: "http://localhost/saml/consume",
-              racComparison: "bad_value" as RacComparison,
-              cert: FAKE_CERT,
-              issuer: "onesaml_login",
-            }).options;
-          },
-          { message: "racComparison must be one of ['exact', 'minimum', 'maximum', 'better']" }
-        );
+        expect(() => {
+          new SAML({
+            callbackUrl: "http://localhost/saml/consume",
+            racComparison: "bad_value" as RacComparison,
+            cert: FAKE_CERT,
+            issuer: "onesaml_login",
+          }).options;
+        }).to.throw("racComparison must be one of ['exact', 'minimum', 'maximum', 'better']");
 
         const samlObjBadComparisonType = new SAML({
           callbackUrl: "http://localhost/saml/consume",


### PR DESCRIPTION
This will remove some instances of using Node `assert` and  replace them with Chai `expect`. The only cases where this substitution wasn't done was for promises as that would make the code arguably less readable and the Node `assert` library isn't `package.json` dependency that we'd otherwise get to remove.