### PR TITLE
Defend against undefined NotOnOrAfter

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -1022,7 +1022,10 @@ class SAML {
           const _confirmData = _subjectConfirmation.SubjectConfirmationData?.[0];
           if (_confirmData?.$) {
             const subjectNotBefore = _confirmData.$.NotBefore;
+
             const subjectNotOnOrAfter = _confirmData.$.NotOnOrAfter;
+            if (subjectNotOnOrAfter == null) return true;
+
             const maxTimeLimitMs = this.calcMaxAgeAssertionTime(
               this.options.maxAssertionAgeMs,
               subjectNotOnOrAfter,

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -1024,13 +1024,14 @@ class SAML {
             const subjectNotBefore = _confirmData.$.NotBefore;
 
             const subjectNotOnOrAfter = _confirmData.$.NotOnOrAfter;
-            if (subjectNotOnOrAfter == null) return true;
 
-            const maxTimeLimitMs = this.calcMaxAgeAssertionTime(
-              this.options.maxAssertionAgeMs,
-              subjectNotOnOrAfter,
-              assertion.$.IssueInstant
-            );
+            const maxTimeLimitMs = subjectNotOnOrAfter
+              ? this.calcMaxAgeAssertionTime(
+                  this.options.maxAssertionAgeMs,
+                  subjectNotOnOrAfter,
+                  assertion.$.IssueInstant
+                )
+              : undefined;
 
             const subjErr = this.checkTimestampsValidityError(
               nowMs,


### PR DESCRIPTION
The [docs](https://github.com/node-saml/node-saml#saml-response-validation---notbefore-and-notonorafter) explain that NotOnOrAfter and NotBefore will only be validated if they exist in the SAML response. I found that this produces a runtime exception that `NotOnOrAfter` is undefined, thrown [here](https://github.com/node-saml/node-saml/blob/master/src/saml.ts#L1340). This was the simplest fix I could find that does not affect any existing tests. Thanks for your time & a great library!