### PR TITLE
Enforce valid setting for validateInResponseTo

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -150,6 +150,10 @@ class SAML {
       racComparison: ctorOptions.racComparison ?? "exact",
     };
 
+    if (!Object.values(ValidateInResponseTo).includes(options.validateInResponseTo)) {
+      throw new TypeError("validateInResponseTo must be one of ['never', 'ifPresent', 'always']");
+    }
+
     /**
      * List of possible values:
      * - exact : Assertion context must exactly match a context in the list

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -1946,6 +1946,34 @@ describe("node-saml /", function () {
           expect(samlObjValidComparisonType.options.racComparison).to.equal(racComparison);
         });
       });
+
+      it("should check the value of the option `validateInResponseTo`", function () {
+        expect(() => {
+          new SAML({
+            callbackUrl: "http://localhost/saml/consume",
+            validateInResponseTo: "bad_value" as ValidateInResponseTo,
+            cert: FAKE_CERT,
+            issuer: "onesaml_login",
+          }).options;
+        }).to.throw("validateInResponseTo must be one of ['never', 'ifPresent', 'always']");
+
+        const validInResponseToTypes: string[] = Object.keys(ValidateInResponseTo);
+        let samlObjValidInResponseToType: SAML;
+        validInResponseToTypes.forEach(function (validateInResponseTo) {
+          samlObjValidInResponseToType = new SAML({
+            callbackUrl: "http://localhost/saml/consume",
+            validateInResponseTo: validateInResponseTo as ValidateInResponseTo,
+            cert: FAKE_CERT,
+            issuer: "onesaml_login",
+          });
+          expect(samlObjValidInResponseToType.options.validateInResponseTo).to.equal(
+            validateInResponseTo,
+          );
+          expect(samlObjValidInResponseToType.options.validateInResponseTo).to.equal(
+            validateInResponseTo,
+          );
+        });
+      });
     });
 
     describe("getAuthorizeMessageAsync checks /", function () {


### PR DESCRIPTION
# Description

This PR addresses the potential security vulnerability I raised in the passport-saml repo here: https://github.com/node-saml/passport-saml/issues/874

* Enforce only valid settings are passed to validateInResponseTo and throw an error if any other value is passed
* Added tests for the new enforcement

A separate PR will be submitted in the passport-saml repo that updates the documentation to reflect these changes.
