### PR TITLE
Support multiple callback urls

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -224,7 +224,10 @@ class SAML {
     }
 
     if (!this.options.disableRequestAcsUrl) {
-      request["samlp:AuthnRequest"]["@AssertionConsumerServiceURL"] = this.options.callbackUrl;
+      const callbackUrl = Array.isArray(this.options.callbackUrl)
+        ? this.options.callbackUrl[0]
+        : this.options.callbackUrl;
+      request["samlp:AuthnRequest"]["@AssertionConsumerServiceURL"] = callbackUrl;
     }
 
     const samlAuthnRequestExtensions = this.options.samlAuthnRequestExtensions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,7 +141,7 @@ export enum ValidateInResponseTo {
  */
 export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlOptions {
   // Core
-  callbackUrl: string;
+  callbackUrl: string | string[];
   entryPoint?: string;
   decryptionPvk?: string | Buffer;
 

--- a/test/static/expected metadata with multiple callback urls.xml
+++ b/test/static/expected metadata with multiple callback urls.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="d700077e-60ad-49c1-b93a-dd1753528708">
+  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="false">
+    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+    <AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
+    <AssertionConsumerService index="2" isDefault="false" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://other.serviceprovider.com/saml/callback"/>
+  </SPSSODescriptor>
+</EntityDescriptor>

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -499,6 +499,26 @@ describe("node-saml /", function () {
         testMetadata(samlConfig, expectedMetadata);
       });
 
+      it("config with multiple callbackUrl should pass", function () {
+        const samlConfig: SamlConfig = {
+          issuer: "http://example.serviceprovider.com",
+          callbackUrl: [
+            "http://example.serviceprovider.com/saml/callback",
+            "http://other.serviceprovider.com/saml/callback",
+          ],
+          identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+          cert: FAKE_CERT,
+          generateUniqueId: () => "d700077e-60ad-49c1-b93a-dd1753528708",
+          wantAssertionsSigned: false,
+        };
+        const expectedMetadata = fs.readFileSync(
+          __dirname + "/static/expected metadata with multiple callback urls.xml",
+          "utf-8",
+        );
+
+        testMetadata(samlConfig, expectedMetadata);
+      });
+
       it("config with protocol, path, and host should pass", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://example.serviceprovider.com/saml/callback",


### PR DESCRIPTION
# Description
Closes #315 
 
This PR adds support for passing multiple callback urls to generate multiple [`AssertionConsumerService`](https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf) properties. 
 
Right now this is done by supporting passing an `string[]` instead of just a `string` for the `callbackUrl`.

Not sure if this is the cleanest solution or if this should be done through another option, something more like `additionalCallbackUrls`.

# Checklist:

- [x] Issue Addressed
- [x] Link to SAML spec
- [x] Tests included?
- [ ] Documentation updated?
