### PR TITLE
Fix metadata order

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -57,8 +57,8 @@ export const generateServiceProviderMetadata = (
         "@protocolSupportEnumeration": "urn:oasis:names:tc:SAML:2.0:protocol",
         "@AuthnRequestsSigned": "false",
       },
-      ...(metadataContactPerson ? { ContactPerson: metadataContactPerson } : {}),
       ...(metadataOrganization ? { Organization: metadataOrganization } : {}),
+      ...(metadataContactPerson ? { ContactPerson: metadataContactPerson } : {}),
     },
   };
 

--- a/test/static/expected_metadata_metadataExtensions.xml
+++ b/test/static/expected_metadata_metadataExtensions.xml
@@ -41,13 +41,13 @@ nwtlCg==
     <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
     <AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
   </SPSSODescriptor>
-  <ContactPerson contactType="support">
-    <GivenName>test</GivenName>
-    <EmailAddress>test@node-saml</EmailAddress>
-  </ContactPerson>
   <Organization>
     <OrganizationName xml:lang="en">node-saml</OrganizationName>
     <OrganizationDisplayName xml:lang="en">node-saml</OrganizationDisplayName>
     <OrganizationURL xml:lang="en">https://github.com/node-saml</OrganizationURL>
   </Organization>
+  <ContactPerson contactType="support">
+    <GivenName>test</GivenName>
+    <EmailAddress>test@node-saml</EmailAddress>
+  </ContactPerson>
 </EntityDescriptor>


### PR DESCRIPTION
Relevant specification at [saml-metadata-2.0-os.pdf](https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf) 

Associated schema [saml-schema-metadata-2.0.xsd](https://docs.oasis-open.org/security/saml/v2.0/saml-schema-metadata-2.0.xsd)

This closes #333

PR include a fix in the associated static test file.

# Checklist:

- Issue Addressed: [X]
- Link to SAML spec: [X]
- Tests included? [X]
- Documentation updated? [ ]
