### PR TITLE
Rename `cert` to `idpCert` and `signingCert` to `publicCert`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const saml = new SAML(options);
 - `entryPoint`: identity provider entrypoint (is required to be spec-compliant when the request is signed)
 - `issuer`: issuer string to supply to identity provider
 - `audience`: expected saml response Audience, defaults to value of Issuer (if `false`, Audience won't be verified)
-- `cert`: the IDP's public signing certificate used to validate the signatures of the incoming SAML Responses, see [Security and signatures](#security-and-signatures)
+- `idpCert`: the IDP's public signing certificate used to validate the signatures of the incoming SAML Responses, see [Security and signatures](#security-and-signatures)
 - `privateKey`: see [Security and signatures](#security-and-signatures).
 - `decryptionPvk`: optional private key that will be used to attempt to decrypt any encrypted assertions that are received
 - `signatureAlgorithm`: valid values are 'sha1', 'sha256', or 'sha512'
@@ -156,13 +156,13 @@ metadataContactPerson:  [{
 // ContactPerson is an array because there can be multiple ContactPerson fields
 ```
 
-### generateServiceProviderMetadata( decryptionCert, signingCert )
+### generateServiceProviderMetadata( decryptionCert, publicCert )
 
 As a convenience, the strategy object exposes a `generateServiceProviderMetadata` method which will generate a service provider metadata document suitable for supplying to an identity provider.
 
 The `decryptionCert` argument should be a public certificate matching the `decryptionPvk` and is required if the strategy is configured with a `decryptionPvk`.
 
-The `signingCert` argument should be a public certificate matching the `privateKey` and is required if the strategy is configured with a `privateKey`. An array of certificates can be provided to support certificate rotation. When supplying an array of certificates, the first entry in the array should match the current `privateKey`. Additional entries in the array can be used to publish upcoming certificates to IdPs before changing the `privateKey`.
+The `publicCert` argument should be a public certificate matching the `privateKey` and is required if the strategy is configured with a `privateKey`. An array of certificates can be provided to support certificate rotation. When supplying an array of certificates, the first entry in the array should match the current `privateKey`. Additional entries in the array can be used to publish upcoming certificates to IdPs before changing the `privateKey`.
 
 ### generateServiceProviderMetadata( params )
 
@@ -225,42 +225,42 @@ or
 2. Alternatively, a single-line or multi-line private key in Base64 format.
    See example from tests of [single line private key](test/static/single_line_acme_tools_com.key).
 
-### Configuration option `cert`
+### Configuration option `idpCert`
 
 It is important to validate the signatures of the incoming SAML Responses.
 For this, provide the Identity Provider's public X.509 signing certificate(s) or public key(s) in [RFC7468](https://www.rfc-editor.org/rfc/rfc7468) `stricttextualmsg` PEM format
-via the `cert` configuration property.
+via the `idpCert` configuration property.
 
 > **Important**, provided public key MUST always be in PEM format!
 
 Add it to options like this:
 
 ```javascript
-cert: "MIICizCCAfQCCQCY8tKaMc0BMjANBgkqh ... W==";
+idpCert: "MIICizCCAfQCCQCY8tKaMc0BMjANBgkqh ... W==";
 ```
 
 or
 
-If the Identity Provider has multiple signing certificates or public keys that are valid then the `cert` configuration property can be an array.
+If the Identity Provider has multiple signing certificates or public keys that are valid then the `idpCert` configuration property can be an array.
 This can be the case during the rolling from an old key to a new key and responses signed with either key are valid:
 
 ```javascript
-cert: ["MIICizCCAfQCCQCY8tKaMc0BMjANBgkqh ... W==", "MIIEOTCCAyGgAwIBAgIJAKZgJdKdCdL6M ... g="];
+idpCert: ["MIICizCCAfQCCQCY8tKaMc0BMjANBgkqh ... W==", "MIIEOTCCAyGgAwIBAgIJAKZgJdKdCdL6M ... g="];
 ```
 
 or
 
-The `cert` configuration property can also be a function that receives a callback as argument calls back a possible error and a certificate or array of certificates
+The `idpCert` configuration property can also be a function that receives a callback as argument calls back a possible error and a certificate or array of certificates
 or a public key or array of public keys.
 This allows the Identity Provider to be polled for valid certificates or public keys and the new certificate or public key can be used if it is changed:
 
 ```javascript
-cert: (callback) => {
+idpCert: (callback) => {
   callback(null, polledCertificates);
 };
 ```
 
-Example formats for `cert` field are,
+Example formats for `idpCert` field are,
 
 1. RFC7468 stricttextualmsg formatted PEM:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   SamlIDPListConfig,
   SamlIDPEntryConfig,
   SignatureAlgorithm,
-  CertCallback,
+  IdpCertCallback,
   AuthOptions,
 } from "./types";
 
@@ -32,6 +32,6 @@ export {
   SamlIDPListConfig,
   SamlIDPEntryConfig,
   SignatureAlgorithm,
-  CertCallback,
+  IdpCertCallback,
   AuthOptions,
 };

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -27,7 +27,7 @@ export const generateServiceProviderMetadata = (
     generateUniqueId = generateUniqueIdDefault,
   } = params;
 
-  let { signingCerts, decryptionCert } = params;
+  let { publicCerts, decryptionCert } = params;
 
   if (decryptionPvk != null) {
     if (!decryptionCert) {
@@ -40,14 +40,14 @@ export const generateServiceProviderMetadata = (
   }
 
   if (privateKey != null) {
-    if (!signingCerts) {
+    if (!publicCerts) {
       throw new Error(
-        "Missing signingCert while generating metadata for signing service provider messages",
+        "Missing publicCert while generating metadata for signing service provider messages",
       );
     }
-    signingCerts = !Array.isArray(signingCerts) ? [signingCerts] : signingCerts;
+    publicCerts = !Array.isArray(publicCerts) ? [publicCerts] : publicCerts;
   } else {
-    signingCerts = null;
+    publicCerts = null;
   }
 
   const metadata: ServiceMetadataXML = {
@@ -65,17 +65,17 @@ export const generateServiceProviderMetadata = (
     },
   };
 
-  if (decryptionCert != null || signingCerts != null) {
+  if (decryptionCert != null || publicCerts != null) {
     metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = [];
     if (isValidSamlSigningOptions(params)) {
       assertRequired(
-        signingCerts,
-        "Missing signingCert while generating metadata for signing service provider messages",
+        publicCerts,
+        "Missing publicCert while generating metadata for signing service provider messages",
       );
 
       metadata.EntityDescriptor.SPSSODescriptor["@AuthnRequestsSigned"] = true;
 
-      const certArray = Array.isArray(signingCerts) ? signingCerts : [signingCerts];
+      const certArray = Array.isArray(publicCerts) ? publicCerts : [publicCerts];
       const signingKeyDescriptors = certArray.map((cert) => ({
         "@use": "signing",
         "ds:KeyInfo": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,15 +74,15 @@ export type SamlStatusXmlJs = {
   ];
 };
 
-export type CertCallback = (
-  callback: (err: Error | null, cert?: string | string[]) => void,
+export type IdpCertCallback = (
+  callback: (err: Error | null, publicCert?: string | string[]) => void,
 ) => void;
 
 /**
  * These are SAML options that must be provided to construct a new SAML Strategy
  */
 export interface MandatorySamlOptions {
-  cert: string | string[] | CertCallback;
+  idpCert: string | string[] | IdpCertCallback;
   issuer: string;
   callbackUrl: string;
 }
@@ -211,7 +211,7 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
 
 export interface GenerateServiceProviderMetadataParams {
   decryptionCert?: string | null;
-  signingCerts?: string | string[] | null;
+  publicCerts?: string | string[] | null;
   issuer: SamlOptions["issuer"];
   callbackUrl: SamlOptions["callbackUrl"];
   logoutCallbackUrl?: SamlOptions["logoutCallbackUrl"];

--- a/test/cache.spec.ts
+++ b/test/cache.spec.ts
@@ -22,7 +22,7 @@ describe("Cache tests /", () => {
       callbackUrl: "http://localhost/saml/consume",
       validateInResponseTo: ValidateInResponseTo.always,
       requestIdExpirationPeriodMs,
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onesaml_login",
     };
     const samlObj = new SAML(samlConfig);
@@ -43,7 +43,7 @@ describe("Cache tests /", () => {
       callbackUrl: "http://localhost/saml/consume",
       validateInResponseTo: ValidateInResponseTo.always,
       requestIdExpirationPeriodMs,
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onesaml_login",
     };
     const samlObj = new SAML(samlConfig);
@@ -73,7 +73,7 @@ describe("Cache tests /", () => {
       callbackUrl: "http://localhost/saml/consume",
       validateInResponseTo: ValidateInResponseTo.always,
       requestIdExpirationPeriodMs,
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onesaml_login",
     };
     const samlObj = new SAML(samlConfig);
@@ -102,7 +102,7 @@ describe("Cache tests /", () => {
       callbackUrl: "http://localhost/saml/consume",
       validateInResponseTo: ValidateInResponseTo.always,
       requestIdExpirationPeriodMs,
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onesaml_login",
     };
     const samlObj = new SAML(samlConfig);
@@ -122,7 +122,7 @@ describe("Cache tests /", () => {
     const samlConfig: SamlConfig = {
       callbackUrl: "http://localhost/saml/consume",
       validateInResponseTo: ValidateInResponseTo.always,
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onesaml_login",
     };
     const samlObj = new SAML(samlConfig);
@@ -149,7 +149,7 @@ describe("Cache tests /", () => {
       callbackUrl: "http://localhost/saml/consume",
       validateInResponseTo: ValidateInResponseTo.always,
       requestIdExpirationPeriodMs,
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onesaml_login",
     };
     const samlObj = new SAML(samlConfig);

--- a/test/samlRequest.spec.ts
+++ b/test/samlRequest.spec.ts
@@ -12,7 +12,7 @@ describe("SAML request", function () {
     const config: SamlConfig = {
       callbackUrl: "http://localhost/saml/consume",
       entryPoint: "https://wwwexampleIdp.com/saml",
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       samlAuthnRequestExtensions: {
         "md:RequestedAttribute": {
           "@isRequired": "true",
@@ -135,7 +135,7 @@ describe("SAML request", function () {
     const config: SamlConfig = {
       callbackUrl: "http://localhost/saml/consume",
       entryPoint: "https://wwwexampleIdp.com/saml",
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onelogin_saml",
     };
 
@@ -223,7 +223,7 @@ describe("SAML request", function () {
     const config: SamlConfig = {
       callbackUrl: "http://localhost/saml/consume",
       entryPoint: "https://wwwexampleIdp.com/saml",
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onelogin_saml",
       identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
       allowCreate: false,
@@ -315,7 +315,7 @@ describe("SAML request", function () {
     const config: SamlConfig = {
       callbackUrl: "http://localhost/saml/consume",
       entryPoint: "https://wwwexampleIdp.com/saml",
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onelogin_saml",
       forceAuthn: true,
       passive: true,
@@ -407,7 +407,7 @@ describe("SAML request", function () {
     const config: SamlConfig = {
       callbackUrl: "http://localhost/saml/consume",
       entryPoint: "https://wwwexampleIdp.com/saml",
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onelogin_saml",
     };
 
@@ -451,7 +451,7 @@ describe("SAML request", function () {
     const config: SamlConfig = {
       callbackUrl: "http://localhost/saml/consume",
       entryPoint: "https://wwwexampleIdp.com/saml",
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onelogin_saml",
       disableRequestedAuthnContext: true,
       skipRequestCompression: true,
@@ -526,7 +526,7 @@ describe("SAML request", function () {
     const config: SamlConfig = {
       callbackUrl: "http://localhost/saml/consume",
       entryPoint: "https://wwwexampleIdp.com/saml",
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       samlAuthnRequestExtensions: "anyValue" as unknown as Record<string, unknown>,
       issuer: "onesaml_login",
     };

--- a/test/samlTests.spec.ts
+++ b/test/samlTests.spec.ts
@@ -5,7 +5,7 @@ import { URL } from "url";
 import { expect } from "chai";
 import * as assert from "assert";
 import { SAML } from "../src/saml";
-import { AuthOptions, CertCallback } from "../src/types";
+import { AuthOptions, IdpCertCallback } from "../src/types";
 import { assertRequired } from "../src/utility";
 import { FAKE_CERT, RequestWithUser, TEST_CERT_MULTILINE } from "./types";
 import { parseDomFromString, parseXml2JsFromString, validateSignature } from "../src/xml";
@@ -18,7 +18,7 @@ describe("saml.ts", function () {
       () =>
         new SAML({
           passive: "false" as unknown as boolean,
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "issuer",
           callbackUrl: "callback",
         }),
@@ -38,11 +38,11 @@ describe("saml.ts", function () {
     });
 
     async function testResolveAndParseKeyInfosPemAsync(
-      cert: string | string[] | CertCallback,
+      idpCert: string | string[] | IdpCertCallback,
     ): Promise<string[]> {
       const samlObj = new SAML({
         callbackUrl: "http://localhost/saml/consume",
-        cert,
+        idpCert,
         issuer: "onesaml_login",
         audience: false,
       });
@@ -103,7 +103,7 @@ describe("saml.ts", function () {
     it("returns PEM files correctly if 'cert' is a callback which returns a PEM formatted certificate", async () => {
       const certificate = fs.readFileSync("./test/static/acme_tools_com.cert").toString();
 
-      const cert: CertCallback = (cb) => {
+      const cert: IdpCertCallback = (cb) => {
         setTimeout(() => {
           cb(null, certificate);
         }, 0);
@@ -117,7 +117,7 @@ describe("saml.ts", function () {
     it("returns PEM files correctly if 'cert' is a callback which returns Array of PEM formatted certificates", async () => {
       const certificate = fs.readFileSync("./test/static/acme_tools_com.cert").toString();
 
-      const cert: CertCallback = (cb) => {
+      const cert: IdpCertCallback = (cb) => {
         setTimeout(() => {
           cb(null, [certificate, certificate]);
         }, 0);
@@ -130,7 +130,7 @@ describe("saml.ts", function () {
     });
 
     it("will fail if 'cert' is a callback which returns invalid value", async () => {
-      const cert: CertCallback = (cb) => {
+      const cert: IdpCertCallback = (cb) => {
         setTimeout(() => {
           cb(null, <never>null);
         }, 0);
@@ -164,7 +164,7 @@ describe("saml.ts", function () {
     it("calls 'resolveAndParseKeyInfosToPem()' to get key infos if 'cert' is not a function", async () => {
       const samlObj = new SAML({
         callbackUrl: "http://localhost/saml/consume",
-        cert: publicKey,
+        idpCert: publicKey,
         issuer: "onesaml_login",
         audience: false,
       });
@@ -176,7 +176,7 @@ describe("saml.ts", function () {
     it("returns cached key infos", async () => {
       const samlObj = new SAML({
         callbackUrl: "http://localhost/saml/consume",
-        cert: publicKey,
+        idpCert: publicKey,
         issuer: "onesaml_login",
         audience: false,
       });
@@ -190,12 +190,12 @@ describe("saml.ts", function () {
     });
 
     it("does not cache key infos if 'cert' is a function", async () => {
-      const cert: CertCallback = (cb) => {
+      const idpCert: IdpCertCallback = (cb) => {
         cb(null, [publicKey]);
       };
       const samlObj = new SAML({
         callbackUrl: "http://localhost/saml/consume",
-        cert,
+        idpCert,
         issuer: "onesaml_login",
         audience: false,
       });
@@ -219,7 +219,7 @@ describe("saml.ts", function () {
         callbackUrl: "http://localhost/saml/consume",
         entryPoint: "https://exampleidp.com/path?key=value",
         logoutUrl: "https://exampleidp.com/path?key=value",
-        cert: FAKE_CERT,
+        idpCert: FAKE_CERT,
         issuer: "onesaml_login",
         generateUniqueId: () => "uniqueId",
       });
@@ -453,7 +453,7 @@ describe("saml.ts", function () {
         expect(() => {
           const samlObj = new SAML({
             callbackUrl: "http://localhost/saml/consume",
-            cert: FAKE_CERT,
+            idpCert: FAKE_CERT,
             issuer: "onesaml_login",
             audience: false,
           });

--- a/test/test-signatures.spec.ts
+++ b/test/test-signatures.spec.ts
@@ -6,7 +6,7 @@ import * as xml from "../src/xml";
 import * as assert from "assert";
 import { expect } from "chai";
 
-const cert = fs.readFileSync(__dirname + "/static/cert.pem", "ascii");
+const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "ascii");
 
 describe("Signatures", function () {
   const INVALID_SIGNATURE = "Invalid signature";
@@ -39,7 +39,7 @@ describe("Signatures", function () {
     //== Instantiate new instance before every test
     const samlObj = new SAML({
       callbackUrl: "http://localhost/saml/consume",
-      cert,
+      idpCert,
       issuer: options.issuer ?? "onesaml_login",
       audience: false,
       ...options,
@@ -100,7 +100,7 @@ describe("Signatures", function () {
     it(
       "R1A - both signed, verify using public key => valid",
       testOneResponse("/valid/response.root-signed.assertion-signed.xml", false, 2, {
-        cert: publicKey,
+        idpCert: publicKey,
       }),
     );
     it(

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -3293,7 +3293,7 @@ describe("node-saml /", function () {
 
     it("matches metadata from SAML object", function () {
       const saml = new SAML({
-        cert: "no_cert_needed_for_metadata",
+        idpCert: "no_cert_needed_for_metadata",
         issuer: "https://www.example.com",
         callbackUrl: "https://www.example.com/callback",
         generateUniqueId: () => "d700077e-60ad-49c1-b93a-dd1753528708",

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -19,15 +19,15 @@ const BAD_TEST_CERT =
 
 describe("node-saml /", function () {
   describe("saml.js / ", function () {
-    it("should throw an error if cert property is provided to saml constructor but is empty", function () {
+    it("should throw an error if idpCert property is provided to saml constructor but is empty", function () {
       expect(function () {
         const strategy = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: undefined as unknown as string,
+          idpCert: undefined as unknown as string,
           issuer: "onelogin_saml",
         });
-        typeof strategy.options.cert === "undefined";
-      }).throw("cert is required");
+        typeof strategy.options.idpCert === "undefined";
+      }).throw("idpCert is required");
     });
 
     it("_generateLogoutRequest", function (done) {
@@ -52,7 +52,7 @@ describe("node-saml /", function () {
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "foo",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onelogin_saml",
         });
         const logoutRequestPromise = samlObj._generateLogoutRequest({
@@ -114,7 +114,7 @@ describe("node-saml /", function () {
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "foo",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onelogin_saml",
         });
         const logoutRequestPromise = samlObj._generateLogoutRequest({
@@ -151,7 +151,7 @@ describe("node-saml /", function () {
       const config: SamlConfig = {
         callbackUrl: "http://localhost/saml/consume",
         entryPoint: "https://wwwexampleIdp.com/saml",
-        cert: FAKE_CERT,
+        idpCert: FAKE_CERT,
         samlLogoutRequestExtensions: "anyvalue" as unknown as Record<string, unknown>,
         issuer: "onelogin_saml",
       };
@@ -201,7 +201,7 @@ describe("node-saml /", function () {
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "foo",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           samlLogoutRequestExtensions: {
             vetuma: {
               "@xmlns": "urn:vetuma:SAML:2.0:extensions",
@@ -264,7 +264,7 @@ describe("node-saml /", function () {
       const samlObj = new SAML({
         callbackUrl: "http://localhost/saml/consume",
         entryPoint: "foo",
-        cert: FAKE_CERT,
+        idpCert: FAKE_CERT,
         issuer: "onelogin_saml",
       });
       const logoutRequest = samlObj._generateLogoutResponse(
@@ -314,7 +314,7 @@ describe("node-saml /", function () {
       const samlObj = new SAML({
         callbackUrl: "http://localhost/saml/consume",
         entryPoint: "foo",
-        cert: FAKE_CERT,
+        idpCert: FAKE_CERT,
         issuer: "onelogin_saml",
       });
       const logoutRequest = samlObj._generateLogoutResponse(
@@ -358,7 +358,7 @@ describe("node-saml /", function () {
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "foo",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onelogin_saml",
         });
         const logoutRequestPromise = samlObj._generateLogoutRequest({
@@ -394,7 +394,7 @@ describe("node-saml /", function () {
       const samlObj = new SAML({
         callbackUrl: "http://localhost/saml/consume",
         entryPoint: "foo",
-        cert: FAKE_CERT,
+        idpCert: FAKE_CERT,
         issuer: "onelogin_saml",
       });
       const cacheSaveSpy = sinon.spy(samlObj.cacheProvider, "saveAsync");
@@ -431,14 +431,14 @@ describe("node-saml /", function () {
       function testMetadata(
         samlConfig: SamlConfig,
         expectedMetadata: string,
-        signingCert?: string | string[],
+        publicCert?: string | string[],
       ) {
         const samlObj = new SAML(samlConfig);
         const decryptionCert = fs.readFileSync(
           __dirname + "/static/testshib encryption cert.pem",
           "utf-8",
         );
-        const metadata = samlObj.generateServiceProviderMetadata(decryptionCert, signingCert);
+        const metadata = samlObj.generateServiceProviderMetadata(decryptionCert, publicCert);
 
         const preparedMetadata = expectedMetadata.split("\n");
 
@@ -453,7 +453,7 @@ describe("node-saml /", function () {
           callbackUrl: "http://example.serviceprovider.com/saml/callback",
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
           decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           generateUniqueId: () => "d700077e-60ad-49c1-b93a-dd1753528708",
           wantAssertionsSigned: false,
         };
@@ -470,7 +470,7 @@ describe("node-saml /", function () {
           issuer: "http://example.serviceprovider.com",
           callbackUrl: "http://example.serviceprovider.com/saml/callback",
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           generateUniqueId: () => "d700077e-60ad-49c1-b93a-dd1753528708",
           wantAssertionsSigned: false,
         };
@@ -488,7 +488,7 @@ describe("node-saml /", function () {
           issuer: "http://example.serviceprovider.com",
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
           decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           generateUniqueId: () => "d700077e-60ad-49c1-b93a-dd1753528708",
           wantAssertionsSigned: false,
         };
@@ -505,7 +505,7 @@ describe("node-saml /", function () {
           callbackUrl: "http://example.serviceprovider.com/saml/callback",
           issuer: "http://example.serviceprovider.com",
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           generateUniqueId: () => "d700077e-60ad-49c1-b93a-dd1753528708",
           wantAssertionsSigned: false,
         };
@@ -524,7 +524,7 @@ describe("node-saml /", function () {
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
           decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
           privateKey: fs.readFileSync(__dirname + "/static/acme_tools_com.key"),
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           generateUniqueId: () => "d700077e-60ad-49c1-b93a-dd1753528708",
           wantAssertionsSigned: false,
         };
@@ -532,19 +532,19 @@ describe("node-saml /", function () {
           __dirname + "/static/expectedMetadataWithBothKeys.xml",
           "utf-8",
         );
-        const signingCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
+        const publicCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
 
-        testMetadata(samlConfig, expectedMetadata, signingCert);
+        testMetadata(samlConfig, expectedMetadata, publicCert);
       });
 
-      it("config with protocol, path, host, decryptionPvk and privateKey, but no signing cert should throw", function () {
+      it("config with protocol, path, host, decryptionPvk and privateKey, but no public cert should throw", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://example.serviceprovider.com/saml/callback",
           issuer: "http://example.serviceprovider.com",
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
           decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
           privateKey: fs.readFileSync(__dirname + "/static/acme_tools_com.key"),
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           generateUniqueId: () => "d700077e-60ad-49c1-b93a-dd1753528708",
           wantAssertionsSigned: false,
         };
@@ -554,7 +554,7 @@ describe("node-saml /", function () {
         );
 
         expect(() => testMetadata(samlConfig, expectedMetadata)).to.throw(
-          "Missing signingCert while generating metadata for signing service provider messages",
+          "Missing publicCert while generating metadata for signing service provider messages",
         );
       });
 
@@ -565,7 +565,7 @@ describe("node-saml /", function () {
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
           decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
           privateKey: fs.readFileSync(__dirname + "/static/acme_tools_com.key"),
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           generateUniqueId: () => "d700077e-60ad-49c1-b93a-dd1753528708",
           wantAssertionsSigned: false,
         };
@@ -573,12 +573,12 @@ describe("node-saml /", function () {
           __dirname + "/static/expectedMetadataWithEncryptionAndTwoSigningKeys.xml",
           "utf-8",
         );
-        const signingCerts = [
+        const publicCerts = [
           fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString(),
           fs.readFileSync(__dirname + "/static/cert.pem").toString(),
         ];
 
-        testMetadata(samlConfig, expectedMetadata, signingCerts);
+        testMetadata(samlConfig, expectedMetadata, publicCerts);
       });
 
       it("generateServiceProviderMetadata contains logout callback url", function () {
@@ -588,7 +588,7 @@ describe("node-saml /", function () {
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
           decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
           logoutCallbackUrl: "http://example.serviceprovider.com/logout",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
         };
 
         const samlObj = new SAML(samlConfig);
@@ -603,7 +603,7 @@ describe("node-saml /", function () {
 
       it("generateServiceProviderMetadata contains WantAssertionsSigned", function () {
         const samlConfig: SamlConfig = {
-          cert: TEST_CERT,
+          idpCert: TEST_CERT,
           issuer: "http://example.serviceprovider.com",
           callbackUrl: "http://example.serviceprovider.com/saml/callback",
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
@@ -621,7 +621,7 @@ describe("node-saml /", function () {
 
       it("generateServiceProviderMetadata throw error", function () {
         const samlConfig: SamlConfig = {
-          cert: TEST_CERT,
+          idpCert: TEST_CERT,
           issuer: "http://example.serviceprovider.com",
           callbackUrl: "http://example.serviceprovider.com/saml/callback",
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
@@ -645,7 +645,7 @@ describe("node-saml /", function () {
 
       it("generateServiceProviderMetadata contains AuthnRequestsSigned", function () {
         const samlConfig: SamlConfig = {
-          cert: TEST_CERT,
+          idpCert: TEST_CERT,
           issuer: "http://example.serviceprovider.com",
           callbackUrl: "http://example.serviceprovider.com/saml/callback",
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
@@ -653,15 +653,15 @@ describe("node-saml /", function () {
         };
 
         const samlObj = new SAML(samlConfig);
-        const signingCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
+        const publicCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
 
-        const metadata = samlObj.generateServiceProviderMetadata(null, signingCert);
+        const metadata = samlObj.generateServiceProviderMetadata(null, publicCert);
         expect(metadata).to.contain('AuthnRequestsSigned="true"');
       });
 
       it("signMetadata creates a valid signature", async function () {
         const samlConfig: SamlConfig = {
-          cert: TEST_CERT,
+          idpCert: TEST_CERT,
           issuer: "http://example.serviceprovider.com",
           callbackUrl: "http://example.serviceprovider.com/saml/callback",
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
@@ -672,12 +672,12 @@ describe("node-saml /", function () {
         };
 
         const samlObj = new SAML(samlConfig);
-        const signingCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
+        const publicCert = fs.readFileSync(__dirname + "/static/acme_tools_com.cert").toString();
 
-        const metadata = samlObj.generateServiceProviderMetadata(null, signingCert);
+        const metadata = samlObj.generateServiceProviderMetadata(null, publicCert);
 
         const dom = await parseDomFromString(metadata);
-        expect(validateSignature(metadata, dom.documentElement, [signingCert])).to.be.true;
+        expect(validateSignature(metadata, dom.documentElement, [publicCert])).to.be.true;
       });
 
       it("generateServiceProviderMetadata contains metadataExtensions", function () {
@@ -686,7 +686,7 @@ describe("node-saml /", function () {
           callbackUrl: "http://example.serviceprovider.com/saml/callback",
           identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
           decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           metadataContactPerson: [
             {
               "@contactType": "support",
@@ -739,7 +739,7 @@ describe("node-saml /", function () {
       it("response with junk content should explain the XML or base64 is not valid", async () => {
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: TEST_CERT,
+          idpCert: TEST_CERT,
           issuer: "onesaml_login",
         });
         await assert.rejects(samlObj.validatePostResponseAsync({ SAMLResponse: "BOOM" }), {
@@ -753,7 +753,7 @@ describe("node-saml /", function () {
         const container = { SAMLResponse: base64xml };
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: `-----BEGIN CERTIFICATE-----\n${TEST_CERT}\n-----END CERTIFICATE-----`,
+          idpCert: `-----BEGIN CERTIFICATE-----\n${TEST_CERT}\n-----END CERTIFICATE-----`,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
         });
@@ -769,7 +769,7 @@ describe("node-saml /", function () {
         const container = { SAMLResponse: base64xml };
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
         });
@@ -785,7 +785,7 @@ describe("node-saml /", function () {
         const container = { SAMLResponse: base64xml };
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
         });
@@ -803,10 +803,10 @@ describe("node-saml /", function () {
 <ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIIDtTCCAp2gAwIBAgIJAKg4VeVcIDz1MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTUwODEzMDE1NDIwWhcNMTUwOTEyMDE1NDIwWjBFMQswCQYDVQQGEwJVUzETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxG3ouM7U+fXbJt69X1H6d4UNg/uRr06pFuU9RkfIwNC+yaXyptqB3ynXKsL7BFt4DCd0fflRvJAx3feJIDp16wN9GDVHcufWMYPhh2j5HcTW/j9JoIJzGhJyvO00YKBt+hHy83iN1SdChKv5y0iSyiPP5GnqFw+ayyHoM6hSO0PqBou1Xb0ZSIE+DHosBnvVna5w2AiPY4xrJl9yZHZ4Q7DfMiYTgstjETio4bX+6oLiBnYktn7DjdEslqhffVme4PuBxNojI+uCeg/sn4QVLd/iogMJfDWNuLD8326Mi/FE9cCRvFlvAiMSaebMI3zPaySsxTK7Zgj5TpEbmbHI9wIDAQABo4GnMIGkMB0GA1UdDgQWBBSVGgvoW4MhMuzBGce29PY8vSzHFzB1BgNVHSMEbjBsgBSVGgvoW4MhMuzBGce29PY8vSzHF6FJpEcwRTELMAkGA1UEBhMCVVMxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAKg4VeVcIDz1MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJu1rqs+anD74dbdwgd3CnqnQsQDJiEXmBhG2leaGt3ve9b/9gKaJg2pyb2NyppDe1uLqh6nNXDuzg1oNZrPz5pJL/eCXPl7FhxhMUi04TtLf8LeNTCIWYZiFuO4pmhohHcv8kRvYR1+6SkLTC8j/TZerm7qvesSiTQFNapa1eNdVQ8nFwVkEtWl+JzKEM1BlRcn42sjJkijeFp7DpI7pU+PnYeiaXpRv5pJo8ogM1iFxN+SnfEs0EuQ7fhKIG9aHKi7bKZ7L6SyX7MDIGLeulEU6lf5D9BfXNmcMambiS0pXhL2QXajt96UBq8FT2KNXY8XNtR4y6MyyCzhaiZZcc8=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></ds:Signature><saml2p:Status><saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Responder"><saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:NoPassive"/></saml2p:StatusCode></saml2p:Status></saml2p:Response>`;
         const base64xml = Buffer.from(xml).toString("base64");
         const container = { SAMLResponse: base64xml };
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: signingCert,
+          idpCert,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
           wantAuthnResponseSigned: false,
@@ -824,11 +824,11 @@ describe("node-saml /", function () {
             .toString("base64"),
         };
 
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
 
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: signingCert,
+          idpCert,
           audience: false,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
@@ -849,13 +849,13 @@ describe("node-saml /", function () {
           "base64",
         );
         const container = { SAMLResponse: base64xml };
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const privateKey = fs.readFileSync(__dirname + "/static/key.pem", "utf-8");
 
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: signingCert,
-          privateKey: privateKey,
+          idpCert,
+          privateKey,
           issuer: "onesaml_login",
           audience: false,
           validateInResponseTo: ValidateInResponseTo.always,
@@ -877,13 +877,13 @@ describe("node-saml /", function () {
           "base64",
         );
         const container = { SAMLResponse: base64xml };
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const privateKey = fs.readFileSync(__dirname + "/static/key.pem", "utf-8");
 
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: signingCert,
-          privateKey: privateKey,
+          idpCert,
+          privateKey,
           issuer: "onesaml_login",
           audience: false,
           validateInResponseTo: ValidateInResponseTo.always,
@@ -906,13 +906,13 @@ describe("node-saml /", function () {
           "base64",
         );
         const container = { SAMLResponse: base64xml };
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const privateKey = fs.readFileSync(__dirname + "/static/key.pem", "utf-8");
 
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: signingCert,
-          privateKey: privateKey,
+          idpCert,
+          privateKey,
           issuer: "onesaml_login",
           audience: false,
           validateInResponseTo: ValidateInResponseTo.always,
@@ -934,13 +934,13 @@ describe("node-saml /", function () {
           "base64",
         );
         const container = { SAMLResponse: base64xml };
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const privateKey = fs.readFileSync(__dirname + "/static/key.pem", "utf-8");
 
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: signingCert,
-          privateKey: privateKey,
+          idpCert,
+          privateKey,
           issuer: "onesaml_login",
           audience: false,
           validateInResponseTo: ValidateInResponseTo.always,
@@ -962,13 +962,13 @@ describe("node-saml /", function () {
           "base64",
         );
         const container = { SAMLResponse: base64xml };
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const privateKey = fs.readFileSync(__dirname + "/static/key.pem", "utf-8");
 
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: signingCert,
-          privateKey: privateKey,
+          idpCert,
+          privateKey,
           issuer: "onesaml_login",
           audience: false,
           validateInResponseTo: ValidateInResponseTo.always,
@@ -988,13 +988,13 @@ describe("node-saml /", function () {
           "base64",
         );
         const container = { SAMLResponse: base64xml };
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const privateKey = fs.readFileSync(__dirname + "/static/key.pem", "utf-8");
 
         const samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: signingCert,
-          privateKey: privateKey,
+          idpCert,
+          privateKey,
           issuer: "onesaml_login",
           audience: false,
           validateInResponseTo: ValidateInResponseTo.always,
@@ -1025,7 +1025,7 @@ describe("node-saml /", function () {
               const samlConfig: SamlConfig = {
                 callbackUrl: "http://localhost/saml/consume",
                 entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-                cert: TEST_CERT,
+                idpCert: TEST_CERT,
                 validateInResponseTo,
                 issuer: "onesaml_login",
                 wantAuthnResponseSigned: false,
@@ -1064,7 +1064,7 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: TEST_CERT,
+          idpCert: TEST_CERT,
           audience: false,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
@@ -1072,7 +1072,7 @@ describe("node-saml /", function () {
         const noAudienceSamlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: TEST_CERT,
+          idpCert: TEST_CERT,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
         };
@@ -1085,7 +1085,7 @@ describe("node-saml /", function () {
         const badCertSamlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: BAD_TEST_CERT,
+          idpCert: BAD_TEST_CERT,
           audience: false,
           issuer: "onesaml_login",
         };
@@ -1185,23 +1185,23 @@ describe("node-saml /", function () {
           expect(profile?.nameID).to.not.be.empty;
         });
 
-        it("must have a cert to construct a SAML object", function () {
+        it("must have a IDP cert to construct a SAML object", function () {
           try {
             new SAML(noCertSamlConfig);
           } catch (err: unknown) {
             expect(err).to.exist;
             expect(err).to.be.instanceOf(Error);
-            expect((err as Error).message).to.match(/cert is required/);
+            expect((err as Error).message).to.match(/idpCert is required/);
           }
         });
 
-        it("must have a valid cert to construct a SAML object", function () {
+        it("must have a valid IDP cert to construct a SAML object", function () {
           try {
             new SAML(badCertSamlConfig);
           } catch (err: unknown) {
             expect(err).to.exist;
             expect(err).to.be.instanceOf(Error);
-            expect((err as Error).message).to.match(/cert is required/);
+            expect((err as Error).message).to.match(/publicCert is required/);
           }
         });
 
@@ -1221,13 +1221,13 @@ describe("node-saml /", function () {
           expect(profile.nameID.startsWith("ploer")).to.be.true;
         });
 
-        it("SAML creation should fail without cert", function () {
+        it("SAML creation should fail without an IDP cert", function () {
           try {
             new SAML(noCertSamlConfig);
           } catch (err: unknown) {
             expect(err).to.exist;
             expect(err).to.be.instanceOf(Error);
-            expect((err as Error).message).to.match(/cert is required/);
+            expect((err as Error).message).to.match(/idpCert is required/);
           }
         });
 
@@ -1321,7 +1321,7 @@ describe("node-saml /", function () {
           const multiCertSamlConfig: SamlConfig = {
             callbackUrl: "http://localhost/saml/consume",
             entryPoint: samlConfig.entryPoint,
-            cert: [ALT_TEST_CERT, TEST_CERT],
+            idpCert: [ALT_TEST_CERT, TEST_CERT],
             audience: false,
             issuer: "onesaml_login",
             wantAuthnResponseSigned: false,
@@ -1340,11 +1340,11 @@ describe("node-saml /", function () {
           expect(profile.nameID.startsWith("ploer")).to.be.true;
         });
 
-        it("cert as a function should validate with the returned cert", async () => {
+        it("idpCert as a function should validate with the returned cert", async () => {
           const functionCertSamlConfig: SamlConfig = {
             callbackUrl: "http://localhost/saml/consume",
             entryPoint: samlConfig.entryPoint,
-            cert: function (callback) {
+            idpCert: function (callback) {
               callback(null, TEST_CERT);
             },
             audience: false,
@@ -1365,11 +1365,11 @@ describe("node-saml /", function () {
           expect(profile.nameID.startsWith("ploer")).to.be.true;
         });
 
-        it("cert as a function should validate with one of the returned certs", async () => {
+        it("idpCert as a function should validate with one of the returned certs", async () => {
           const functionMultiCertSamlConfig: SamlConfig = {
             callbackUrl: "http://localhost/saml/consume",
             entryPoint: samlConfig.entryPoint,
-            cert: function (callback) {
+            idpCert: function (callback) {
               callback(null, [ALT_TEST_CERT, TEST_CERT]);
             },
             audience: false,
@@ -1390,12 +1390,12 @@ describe("node-saml /", function () {
           expect(profile.nameID.startsWith("ploer")).to.be.true;
         });
 
-        it("cert as a function should return an error if the cert function returns an error", async () => {
+        it("idpCert as a function should return an error if the idpCert function returns an error", async () => {
           const errorToReturn = new Error("test");
           const functionErrorCertSamlConfig: SamlConfig = {
             callbackUrl: "http://localhost/saml/consume",
             entryPoint: samlConfig.entryPoint,
-            cert: function (callback) {
+            idpCert: function (callback) {
               callback(errorToReturn);
             },
             issuer: "onesaml_login",
@@ -1445,7 +1445,7 @@ describe("node-saml /", function () {
             "</Response>";
 
           const signingKey = fs.readFileSync(__dirname + "/static/key.pem");
-          const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+          const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
           const signedXml = signXmlResponse(xml, {
             privateKey: signingKey,
             signatureAlgorithm: "sha1",
@@ -1455,7 +1455,7 @@ describe("node-saml /", function () {
           const container = { SAMLResponse: base64xml };
           const samlObj = new SAML({
             callbackUrl: "http://localhost/saml/consume",
-            cert: signingCert,
+            idpCert,
             audience: false,
             issuer: "onesaml_login",
             wantAssertionsSigned: false,
@@ -1499,7 +1499,7 @@ describe("node-saml /", function () {
           const container = { SAMLResponse: base64xml };
           const samlObj = new SAML({
             callbackUrl: "http://localhost/saml/consume",
-            cert: TEST_CERT,
+            idpCert: TEST_CERT,
             issuer: "onesaml_login",
             wantAuthnResponseSigned: false,
           });
@@ -1524,7 +1524,7 @@ describe("node-saml /", function () {
             "</Response>";
 
           const signingKey = fs.readFileSync(__dirname + "/static/key.pem");
-          const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+          const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
           const signedXml = signXmlResponse(xml, {
             privateKey: signingKey,
             signatureAlgorithm: "sha1",
@@ -1534,7 +1534,7 @@ describe("node-saml /", function () {
           const container = { SAMLResponse: base64xml };
           const samlObj = new SAML({
             callbackUrl: "http://localhost/saml/consume",
-            cert: signingCert,
+            idpCert,
             audience: false,
             issuer: "onesaml_login",
             wantAssertionsSigned: false,
@@ -1571,7 +1571,7 @@ describe("node-saml /", function () {
           additionalParams: {
             customQueryStringParam: "CustomQueryStringParamValue",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           generateUniqueId: () => "_12345678901234567890",
           skipRequestCompression: true,
         };
@@ -1598,7 +1598,7 @@ describe("node-saml /", function () {
           additionalParams: {
             customQueryStringParam: "CustomQueryStringParamValue",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           generateUniqueId: () => "_12345678901234567890",
         };
         const samlObj = new SAML(samlConfig);
@@ -1622,7 +1622,7 @@ describe("node-saml /", function () {
           additionalParams: {
             customQueryStringParam: "CustomQueryStringParamValue",
           },
-          cert: fs.readFileSync(__dirname + "/static/acme_tools_com.cert", "utf-8"),
+          idpCert: fs.readFileSync(__dirname + "/static/acme_tools_com.cert", "utf-8"),
           generateUniqueId: () => "_12345678901234567890",
           skipRequestCompression: true,
         };
@@ -1649,7 +1649,7 @@ describe("node-saml /", function () {
           additionalParams: {
             customQueryStringParam: "CustomQueryStringParamValue",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           generateUniqueId: () => "_12345678901234567890",
           skipRequestCompression: true,
         };
@@ -1669,7 +1669,7 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -1684,7 +1684,7 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -1701,7 +1701,7 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -1723,7 +1723,7 @@ describe("node-saml /", function () {
           additionalParams: {
             queryParam: "queryParamValue",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -1742,7 +1742,7 @@ describe("node-saml /", function () {
           additionalAuthorizeParams: {
             queryParam: "queryParamValue",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -1762,7 +1762,7 @@ describe("node-saml /", function () {
           additionalLogoutParams: {
             queryParam: "queryParamValue",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -1788,7 +1788,7 @@ describe("node-saml /", function () {
           additionalLogoutParams: {
             queryParam2: "queryParamValueLogout",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -1821,7 +1821,7 @@ describe("node-saml /", function () {
           additionalLogoutParams: {
             queryParam2: "queryParamValueLogout",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -1869,7 +1869,7 @@ describe("node-saml /", function () {
           additionalLogoutParams: {
             queryParam: "queryParamValueLogout",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -1896,7 +1896,7 @@ describe("node-saml /", function () {
           additionalLogoutParams: {
             queryParam: "queryParamValueLogout",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -1928,14 +1928,14 @@ describe("node-saml /", function () {
           new SAML({
             callbackUrl: "http://localhost/saml/consume",
             racComparison: "bad_value" as RacComparison,
-            cert: FAKE_CERT,
+            idpCert: FAKE_CERT,
             issuer: "onesaml_login",
           }).options;
         }).to.throw("racComparison must be one of ['exact', 'minimum', 'maximum', 'better']");
 
         const samlObjBadComparisonType = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         });
         expect(samlObjBadComparisonType.options.racComparison).equal(
@@ -1949,7 +1949,7 @@ describe("node-saml /", function () {
           samlObjValidComparisonType = new SAML({
             callbackUrl: "http://localhost/saml/consume",
             racComparison,
-            cert: FAKE_CERT,
+            idpCert: FAKE_CERT,
             issuer: "onesaml_login",
           });
           expect(samlObjValidComparisonType.options.racComparison).to.equal(racComparison);
@@ -1962,7 +1962,7 @@ describe("node-saml /", function () {
           new SAML({
             callbackUrl: "http://localhost/saml/consume",
             validateInResponseTo: "bad_value" as ValidateInResponseTo,
-            cert: FAKE_CERT,
+            idpCert: FAKE_CERT,
             issuer: "onesaml_login",
           }).options;
         }).to.throw("validateInResponseTo must be one of ['never', 'ifPresent', 'always']");
@@ -1973,7 +1973,7 @@ describe("node-saml /", function () {
           samlObjValidInResponseToType = new SAML({
             callbackUrl: "http://localhost/saml/consume",
             validateInResponseTo: validateInResponseTo as ValidateInResponseTo,
-            cert: FAKE_CERT,
+            idpCert: FAKE_CERT,
             issuer: "onesaml_login",
           });
           expect(samlObjValidInResponseToType.options.validateInResponseTo).to.equal(
@@ -1991,7 +1991,7 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -2005,7 +2005,7 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -2020,7 +2020,7 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -2040,7 +2040,7 @@ describe("node-saml /", function () {
           additionalParams: {
             queryParam: "queryParamValue",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -2058,7 +2058,7 @@ describe("node-saml /", function () {
           additionalAuthorizeParams: {
             queryParam: "queryParamValue",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -2079,7 +2079,7 @@ describe("node-saml /", function () {
           additionalAuthorizeParams: {
             queryParam2: "queryParamValueAuthorize",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -2103,7 +2103,7 @@ describe("node-saml /", function () {
           additionalAuthorizeParams: {
             queryParam2: "queryParamValueAuthorize",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -2128,7 +2128,7 @@ describe("node-saml /", function () {
           additionalAuthorizeParams: {
             queryParam: "queryParamValueAuthorize",
           },
-          cert: FAKE_CERT,
+          idpCert: FAKE_CERT,
           issuer: "onesaml_login",
         };
         const samlObj = new SAML(samlConfig);
@@ -2166,7 +2166,7 @@ describe("node-saml /", function () {
               const samlConfig: SamlConfig = {
                 callbackUrl: "http://localhost/saml/consume",
                 entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-                cert: TEST_CERT,
+                idpCert: TEST_CERT,
                 validateInResponseTo,
                 audience: false,
                 issuer: "onesaml_login",
@@ -2197,7 +2197,8 @@ describe("node-saml /", function () {
               const samlConfig: SamlConfig = {
                 callbackUrl: "http://localhost/saml/consume",
                 entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-                cert: "MIIC7TCCAdmgAwIBAgIQuIdqos+9yKBC4oygbhtdfzAJBgUrDgMCHQUAMBIxEDAOBgNVBAMTB1Rlc3RTVFMwHhcNMTQwNDE2MTIyMTEwWhcNMzkxMjMxMjM1OTU5WjASMRAwDgYDVQQDEwdUZXN0U1RTMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmhReamVYbeOWwrrAvHPvS9KKBwv4Tj7wOSGDXbNgfjhSvVyXsnpYRcuoJkvE8b9tCjFTbXCfbhnaVrpoXaWFtP1YvUIZvCJGdOOTXltMNDlNIaFmsIsomza8IyOHXe+3xHWVtxO8FG3qnteSkkVIQuAvBqpPfQtxrXCZOlbQZm7q69QIQ64JvLJfRwHN1EywMBVwbJgrV8gBdE3RITI76coSOK13OBTlGtB0kGKLDrF2JW+5mB+WnFR7GlXUj+V0R9WStBomVipJEwr6Q3fU0deKZ5lLw0+qJ0T6APInwN5TIN/AbFCHd51aaf3zEP+tZacQ9fbZqy9XBAtL2pCAJQIDAQABo0cwRTBDBgNVHQEEPDA6gBDECazhZ8Ar+ULXb0YTs5MvoRQwEjEQMA4GA1UEAxMHVGVzdFNUU4IQuIdqos+9yKBC4oygbhtdfzAJBgUrDgMCHQUAA4IBAQAioMSOU9QFw+yhVxGUNK0p/ghVsHnYdeOE3vSRhmFPsetBt8S35sI4QwnQNiuiEYqp++FabiHgePOiqq5oeY6ekJik1qbs7fgwnaQXsxxSucHvc4BU81x24aKy6jeJzxmFxo3mh6y/OI1peCMSH48iUzmhnoSulp0+oAs3gMEFI0ONbgAA/XoAHaVEsrPj10i3gkztoGdpH0DYUe9rABOJxX/3mNF+dCVJG7t7BoSlNAWlSDErKciNNax1nBskFqNWNIKzUKBIb+GVKkIB2QpATMQB6Oe7inUdT9kkZ/Q7oPBATZk+3mFsIoWr8QRFSqvToOhun7EY2/VtuiV1d932",
+                idpCert:
+                  "MIIC7TCCAdmgAwIBAgIQuIdqos+9yKBC4oygbhtdfzAJBgUrDgMCHQUAMBIxEDAOBgNVBAMTB1Rlc3RTVFMwHhcNMTQwNDE2MTIyMTEwWhcNMzkxMjMxMjM1OTU5WjASMRAwDgYDVQQDEwdUZXN0U1RTMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmhReamVYbeOWwrrAvHPvS9KKBwv4Tj7wOSGDXbNgfjhSvVyXsnpYRcuoJkvE8b9tCjFTbXCfbhnaVrpoXaWFtP1YvUIZvCJGdOOTXltMNDlNIaFmsIsomza8IyOHXe+3xHWVtxO8FG3qnteSkkVIQuAvBqpPfQtxrXCZOlbQZm7q69QIQ64JvLJfRwHN1EywMBVwbJgrV8gBdE3RITI76coSOK13OBTlGtB0kGKLDrF2JW+5mB+WnFR7GlXUj+V0R9WStBomVipJEwr6Q3fU0deKZ5lLw0+qJ0T6APInwN5TIN/AbFCHd51aaf3zEP+tZacQ9fbZqy9XBAtL2pCAJQIDAQABo0cwRTBDBgNVHQEEPDA6gBDECazhZ8Ar+ULXb0YTs5MvoRQwEjEQMA4GA1UEAxMHVGVzdFNUU4IQuIdqos+9yKBC4oygbhtdfzAJBgUrDgMCHQUAA4IBAQAioMSOU9QFw+yhVxGUNK0p/ghVsHnYdeOE3vSRhmFPsetBt8S35sI4QwnQNiuiEYqp++FabiHgePOiqq5oeY6ekJik1qbs7fgwnaQXsxxSucHvc4BU81x24aKy6jeJzxmFxo3mh6y/OI1peCMSH48iUzmhnoSulp0+oAs3gMEFI0ONbgAA/XoAHaVEsrPj10i3gkztoGdpH0DYUe9rABOJxX/3mNF+dCVJG7t7BoSlNAWlSDErKciNNax1nBskFqNWNIKzUKBIb+GVKkIB2QpATMQB6Oe7inUdT9kkZ/Q7oPBATZk+3mFsIoWr8QRFSqvToOhun7EY2/VtuiV1d932",
                 validateInResponseTo,
                 audience: false,
                 issuer: "onesaml_login",
@@ -2233,7 +2234,7 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: TEST_CERT,
+          idpCert: TEST_CERT,
           validateInResponseTo: ValidateInResponseTo.always,
           issuer: "onesaml_login",
         };
@@ -2255,7 +2256,8 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: "MIICrjCCAZYCCQDWybyUsLVkXzANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDFA5hY21lX3Rvb2xzLmNvbTAeFw0xNTA4MTgwODQ3MzZaFw0yNTA4MTcwODQ3MzZaMBkxFzAVBgNVBAMUDmFjbWVfdG9vbHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlyT+OzEymhaZFNfx4+HFxZbBP3egvcUgPvGa7wWCV7vyuCauLBqwO1FQqzaRDxkEihkHqmUz63D25v2QixLxXyqaFQ8TxDFKwYATtSL7x5G2Gww56H0L1XGgYdNW1akPx90P+USmVn1Wb//7AwU+TV+u4jIgKZyTaIFWdFlwBhlp4OBEHCyYwngFgMyVoCBsSmwb4if7Mi5T746J9ZMQpC+ts+kfzley59Nz55pa5fRLwu4qxFUv2oRdXAf2ZLuxB7DPQbRH82/ewZZ8N4BUGiQyAwOsHgp0sb9JJ8uEM/qhyS1dXXxjo+kxsI5HXhxp4P5R9VADuOquaLIo8ptIrQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBW/Y7leJnV76+6bzeqqi+buTLyWc1mASi5LVH68mdailg2WmGfKlSMLGzFkNtg8fJnfaRZ/GtxmSxhpQRHn63ZlyzqVrFcJa0qzPG21PXPHG/ny8pN+BV8fk74CIb/+YN7NvDUrV7jlsPxNT2rQk8G2fM7jsTMYvtz0MBkrZZsUzTv4rZkF/v44J/ACDirKJiE+TYArm70yQPweX6RvYHNZLSzgg4o+hoyBXo5BGQetAjmcIhC6ZOwN3iVhGjp0YpWM0pkqStPy3sIR0//LZbskWWlSRb0fX1c4632Xb+zikfec4DniYV6CxkB2U+plHpOX1rt1R+UiTEIhTSXPNt/",
+          idpCert:
+            "MIICrjCCAZYCCQDWybyUsLVkXzANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDFA5hY21lX3Rvb2xzLmNvbTAeFw0xNTA4MTgwODQ3MzZaFw0yNTA4MTcwODQ3MzZaMBkxFzAVBgNVBAMUDmFjbWVfdG9vbHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlyT+OzEymhaZFNfx4+HFxZbBP3egvcUgPvGa7wWCV7vyuCauLBqwO1FQqzaRDxkEihkHqmUz63D25v2QixLxXyqaFQ8TxDFKwYATtSL7x5G2Gww56H0L1XGgYdNW1akPx90P+USmVn1Wb//7AwU+TV+u4jIgKZyTaIFWdFlwBhlp4OBEHCyYwngFgMyVoCBsSmwb4if7Mi5T746J9ZMQpC+ts+kfzley59Nz55pa5fRLwu4qxFUv2oRdXAf2ZLuxB7DPQbRH82/ewZZ8N4BUGiQyAwOsHgp0sb9JJ8uEM/qhyS1dXXxjo+kxsI5HXhxp4P5R9VADuOquaLIo8ptIrQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBW/Y7leJnV76+6bzeqqi+buTLyWc1mASi5LVH68mdailg2WmGfKlSMLGzFkNtg8fJnfaRZ/GtxmSxhpQRHn63ZlyzqVrFcJa0qzPG21PXPHG/ny8pN+BV8fk74CIb/+YN7NvDUrV7jlsPxNT2rQk8G2fM7jsTMYvtz0MBkrZZsUzTv4rZkF/v44J/ACDirKJiE+TYArm70yQPweX6RvYHNZLSzgg4o+hoyBXo5BGQetAjmcIhC6ZOwN3iVhGjp0YpWM0pkqStPy3sIR0//LZbskWWlSRb0fX1c4632Xb+zikfec4DniYV6CxkB2U+plHpOX1rt1R+UiTEIhTSXPNt/",
           validateInResponseTo: ValidateInResponseTo.always,
           issuer: "onesaml_login",
         };
@@ -2292,7 +2294,7 @@ describe("node-saml /", function () {
               const samlConfig: SamlConfig = {
                 callbackUrl: "http://localhost/saml/consume",
                 entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-                cert: TEST_CERT,
+                idpCert: TEST_CERT,
                 validateInResponseTo,
                 audience: false,
                 issuer: "onesaml_login",
@@ -2319,7 +2321,8 @@ describe("node-saml /", function () {
               const samlConfig: SamlConfig = {
                 callbackUrl: "http://localhost/saml/consume",
                 entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-                cert: "MIICrjCCAZYCCQDWybyUsLVkXzANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDFA5hY21lX3Rvb2xzLmNvbTAeFw0xNTA4MTgwODQ3MzZaFw0yNTA4MTcwODQ3MzZaMBkxFzAVBgNVBAMUDmFjbWVfdG9vbHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlyT+OzEymhaZFNfx4+HFxZbBP3egvcUgPvGa7wWCV7vyuCauLBqwO1FQqzaRDxkEihkHqmUz63D25v2QixLxXyqaFQ8TxDFKwYATtSL7x5G2Gww56H0L1XGgYdNW1akPx90P+USmVn1Wb//7AwU+TV+u4jIgKZyTaIFWdFlwBhlp4OBEHCyYwngFgMyVoCBsSmwb4if7Mi5T746J9ZMQpC+ts+kfzley59Nz55pa5fRLwu4qxFUv2oRdXAf2ZLuxB7DPQbRH82/ewZZ8N4BUGiQyAwOsHgp0sb9JJ8uEM/qhyS1dXXxjo+kxsI5HXhxp4P5R9VADuOquaLIo8ptIrQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBW/Y7leJnV76+6bzeqqi+buTLyWc1mASi5LVH68mdailg2WmGfKlSMLGzFkNtg8fJnfaRZ/GtxmSxhpQRHn63ZlyzqVrFcJa0qzPG21PXPHG/ny8pN+BV8fk74CIb/+YN7NvDUrV7jlsPxNT2rQk8G2fM7jsTMYvtz0MBkrZZsUzTv4rZkF/v44J/ACDirKJiE+TYArm70yQPweX6RvYHNZLSzgg4o+hoyBXo5BGQetAjmcIhC6ZOwN3iVhGjp0YpWM0pkqStPy3sIR0//LZbskWWlSRb0fX1c4632Xb+zikfec4DniYV6CxkB2U+plHpOX1rt1R+UiTEIhTSXPNt/",
+                idpCert:
+                  "MIICrjCCAZYCCQDWybyUsLVkXzANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDFA5hY21lX3Rvb2xzLmNvbTAeFw0xNTA4MTgwODQ3MzZaFw0yNTA4MTcwODQ3MzZaMBkxFzAVBgNVBAMUDmFjbWVfdG9vbHMuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlyT+OzEymhaZFNfx4+HFxZbBP3egvcUgPvGa7wWCV7vyuCauLBqwO1FQqzaRDxkEihkHqmUz63D25v2QixLxXyqaFQ8TxDFKwYATtSL7x5G2Gww56H0L1XGgYdNW1akPx90P+USmVn1Wb//7AwU+TV+u4jIgKZyTaIFWdFlwBhlp4OBEHCyYwngFgMyVoCBsSmwb4if7Mi5T746J9ZMQpC+ts+kfzley59Nz55pa5fRLwu4qxFUv2oRdXAf2ZLuxB7DPQbRH82/ewZZ8N4BUGiQyAwOsHgp0sb9JJ8uEM/qhyS1dXXxjo+kxsI5HXhxp4P5R9VADuOquaLIo8ptIrQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBW/Y7leJnV76+6bzeqqi+buTLyWc1mASi5LVH68mdailg2WmGfKlSMLGzFkNtg8fJnfaRZ/GtxmSxhpQRHn63ZlyzqVrFcJa0qzPG21PXPHG/ny8pN+BV8fk74CIb/+YN7NvDUrV7jlsPxNT2rQk8G2fM7jsTMYvtz0MBkrZZsUzTv4rZkF/v44J/ACDirKJiE+TYArm70yQPweX6RvYHNZLSzgg4o+hoyBXo5BGQetAjmcIhC6ZOwN3iVhGjp0YpWM0pkqStPy3sIR0//LZbskWWlSRb0fX1c4632Xb+zikfec4DniYV6CxkB2U+plHpOX1rt1R+UiTEIhTSXPNt/",
                 validateInResponseTo,
                 audience: false,
                 issuer: "onesaml_login",
@@ -2357,7 +2360,7 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: TEST_CERT,
+          idpCert: TEST_CERT,
           validateInResponseTo: ValidateInResponseTo.never,
           audience: false,
           issuer: "onesaml_login",
@@ -2383,7 +2386,8 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: "MIIDtTCCAp2gAwIBAgIJAKg4VeVcIDz1MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTUwODEzMDE1NDIwWhcNMTUwOTEyMDE1NDIwWjBFMQswCQYDVQQGEwJVUzETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxG3ouM7U+fXbJt69X1H6d4UNg/uRr06pFuU9RkfIwNC+yaXyptqB3ynXKsL7BFt4DCd0fflRvJAx3feJIDp16wN9GDVHcufWMYPhh2j5HcTW/j9JoIJzGhJyvO00YKBt+hHy83iN1SdChKv5y0iSyiPP5GnqFw+ayyHoM6hSO0PqBou1Xb0ZSIE+DHosBnvVna5w2AiPY4xrJl9yZHZ4Q7DfMiYTgstjETio4bX+6oLiBnYktn7DjdEslqhffVme4PuBxNojI+uCeg/sn4QVLd/iogMJfDWNuLD8326Mi/FE9cCRvFlvAiMSaebMI3zPaySsxTK7Zgj5TpEbmbHI9wIDAQABo4GnMIGkMB0GA1UdDgQWBBSVGgvoW4MhMuzBGce29PY8vSzHFzB1BgNVHSMEbjBsgBSVGgvoW4MhMuzBGce29PY8vSzHF6FJpEcwRTELMAkGA1UEBhMCVVMxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAKg4VeVcIDz1MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJu1rqs+anD74dbdwgd3CnqnQsQDJiEXmBhG2leaGt3ve9b/9gKaJg2pyb2NyppDe1uLqh6nNXDuzg1oNZrPz5pJL/eCXPl7FhxhMUi04TtLf8LeNTCIWYZiFuO4pmhohHcv8kRvYR1+6SkLTC8j/TZerm7qvesSiTQFNapa1eNdVQ8nFwVkEtWl+JzKEM1BlRcn42sjJkijeFp7DpI7pU+PnYeiaXpRv5pJo8ogM1iFxN+SnfEs0EuQ7fhKIG9aHKi7bKZ7L6SyX7MDIGLeulEU6lf5D9BfXNmcMambiS0pXhL2QXajt96UBq8FT2KNXY8XNtR4y6MyyCzhaiZZcc8=",
+          idpCert:
+            "MIIDtTCCAp2gAwIBAgIJAKg4VeVcIDz1MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTUwODEzMDE1NDIwWhcNMTUwOTEyMDE1NDIwWjBFMQswCQYDVQQGEwJVUzETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxG3ouM7U+fXbJt69X1H6d4UNg/uRr06pFuU9RkfIwNC+yaXyptqB3ynXKsL7BFt4DCd0fflRvJAx3feJIDp16wN9GDVHcufWMYPhh2j5HcTW/j9JoIJzGhJyvO00YKBt+hHy83iN1SdChKv5y0iSyiPP5GnqFw+ayyHoM6hSO0PqBou1Xb0ZSIE+DHosBnvVna5w2AiPY4xrJl9yZHZ4Q7DfMiYTgstjETio4bX+6oLiBnYktn7DjdEslqhffVme4PuBxNojI+uCeg/sn4QVLd/iogMJfDWNuLD8326Mi/FE9cCRvFlvAiMSaebMI3zPaySsxTK7Zgj5TpEbmbHI9wIDAQABo4GnMIGkMB0GA1UdDgQWBBSVGgvoW4MhMuzBGce29PY8vSzHFzB1BgNVHSMEbjBsgBSVGgvoW4MhMuzBGce29PY8vSzHF6FJpEcwRTELMAkGA1UEBhMCVVMxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAKg4VeVcIDz1MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAJu1rqs+anD74dbdwgd3CnqnQsQDJiEXmBhG2leaGt3ve9b/9gKaJg2pyb2NyppDe1uLqh6nNXDuzg1oNZrPz5pJL/eCXPl7FhxhMUi04TtLf8LeNTCIWYZiFuO4pmhohHcv8kRvYR1+6SkLTC8j/TZerm7qvesSiTQFNapa1eNdVQ8nFwVkEtWl+JzKEM1BlRcn42sjJkijeFp7DpI7pU+PnYeiaXpRv5pJo8ogM1iFxN+SnfEs0EuQ7fhKIG9aHKi7bKZ7L6SyX7MDIGLeulEU6lf5D9BfXNmcMambiS0pXhL2QXajt96UBq8FT2KNXY8XNtR4y6MyyCzhaiZZcc8=",
           validateInResponseTo: ValidateInResponseTo.always,
           audience: false,
           issuer: "onesaml_login",
@@ -2414,7 +2418,7 @@ describe("node-saml /", function () {
       const samlConfig: SamlConfig = {
         callbackUrl: "http://localhost/saml/consume",
         entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-        cert: TEST_CERT,
+        idpCert: TEST_CERT,
         audience: false,
         issuer: "onesaml_login",
         wantAssertionsSigned: false,
@@ -2497,7 +2501,7 @@ describe("node-saml /", function () {
           "</samlp:Response>";
 
         const signingKey = fs.readFileSync(__dirname + "/static/key.pem");
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const signedXml = signXmlResponse(unsignedXml, {
           privateKey: signingKey,
           signatureAlgorithm: "sha1",
@@ -2505,7 +2509,7 @@ describe("node-saml /", function () {
 
         const base64xml = Buffer.from(signedXml).toString("base64");
         const container = { SAMLResponse: base64xml };
-        const samlObj = new SAML({ ...samlConfig, cert: signingCert });
+        const samlObj = new SAML({ ...samlConfig, idpCert });
 
         fakeClock.restore();
         fakeClock = sinon.useFakeTimers(Date.parse("2014-05-28T00:13:07Z"));
@@ -2565,7 +2569,7 @@ describe("node-saml /", function () {
         const samlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
-          cert: TEST_CERT,
+          idpCert: TEST_CERT,
           acceptedClockSkewMs: -1,
           audience: false,
           issuer: "onesaml_login",
@@ -2590,7 +2594,7 @@ describe("node-saml /", function () {
           "</samlp:Response>";
 
         const signingKey = fs.readFileSync(__dirname + "/static/key.pem");
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const signedXml = signXmlResponse(unsignedXml, {
           privateKey: signingKey,
           signatureAlgorithm: "sha1",
@@ -2598,7 +2602,7 @@ describe("node-saml /", function () {
 
         const base64xml = Buffer.from(signedXml).toString("base64");
         const container = { SAMLResponse: base64xml };
-        const samlObj = new SAML({ ...samlConfig, cert: signingCert });
+        const samlObj = new SAML({ ...samlConfig, idpCert });
 
         fakeClock.restore();
         fakeClock = sinon.useFakeTimers(Date.parse("2014-05-28T00:13:07Z"));
@@ -2615,7 +2619,7 @@ describe("node-saml /", function () {
           "</samlp:Response>";
 
         const signingKey = fs.readFileSync(__dirname + "/static/key.pem");
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const signedXml = signXmlResponse(unsignedXml, {
           privateKey: signingKey,
           signatureAlgorithm: "sha1",
@@ -2623,7 +2627,7 @@ describe("node-saml /", function () {
 
         const base64xml = Buffer.from(signedXml).toString("base64");
         const container = { SAMLResponse: base64xml };
-        const samlObj = new SAML({ ...samlConfig, cert: signingCert });
+        const samlObj = new SAML({ ...samlConfig, idpCert });
 
         fakeClock.restore();
         fakeClock = sinon.useFakeTimers(Date.parse("2014-05-28T00:13:07Z"));
@@ -2687,7 +2691,7 @@ describe("node-saml /", function () {
         `;
 
         const signingKey = fs.readFileSync(__dirname + "/static/key.pem");
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const signedXml = signXmlResponse(unsignedXml, {
           privateKey: signingKey,
           signatureAlgorithm: "sha1",
@@ -2695,7 +2699,7 @@ describe("node-saml /", function () {
 
         const base64xml = Buffer.from(signedXml).toString("base64");
         const container = { SAMLResponse: base64xml };
-        const samlObj = new SAML({ ...samlConfig, cert: signingCert });
+        const samlObj = new SAML({ ...samlConfig, idpCert });
 
         fakeClock.restore();
         fakeClock = sinon.useFakeTimers(Date.parse("2014-05-28T00:13:07Z"));
@@ -2705,7 +2709,7 @@ describe("node-saml /", function () {
       });
 
       it("onelogin xml document with audience and no AudienceRestriction should not pass", async () => {
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const xml = `<samlp:Response xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="pfx1e2f568f-ba3e-9d81-af54-ab41fdbc648e" Version="2.0" IssueInstant="2014-05-28T00:16:08Z" Destination="{recipient}" InResponseTo="_a6fc46be84e1e3cf3c50">
   <saml:Issuer>https://app.onelogin.com/saml/metadata/371755</saml:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
   <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
@@ -2739,7 +2743,7 @@ describe("node-saml /", function () {
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
           audience: "http://sp.example.com",
           acceptedClockSkewMs: -1,
-          cert: signingCert,
+          idpCert,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
         };
@@ -2750,7 +2754,7 @@ describe("node-saml /", function () {
       });
 
       it("onelogin xml document with audience not matching AudienceRestriction should not pass", async () => {
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const xml = `<samlp:Response xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="pfxeda919ac-e0ca-fff5-4987-efd3b459a1d5" Version="2.0" IssueInstant="2014-05-28T00:16:08Z" Destination="{recipient}" InResponseTo="_a6fc46be84e1e3cf3c50">
   <saml:Issuer>https://app.onelogin.com/saml/metadata/371755</saml:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
   <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
@@ -2788,7 +2792,7 @@ describe("node-saml /", function () {
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
           audience: "http://sp.example.com",
           acceptedClockSkewMs: -1,
-          cert: signingCert,
+          idpCert,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
         };
@@ -2800,7 +2804,7 @@ describe("node-saml /", function () {
       });
 
       it("onelogin xml document with audience matching AudienceRestriction should pass", async () => {
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const xml = `<samlp:Response xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="pfx9bf4fce3-7a3c-5530-22c9-d7c66cdaac4e" Version="2.0" IssueInstant="2014-05-28T00:16:08Z" Destination="{recipient}" InResponseTo="_a6fc46be84e1e3cf3c50">
   <saml:Issuer>https://app.onelogin.com/saml/metadata/371755</saml:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
   <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
@@ -2838,7 +2842,7 @@ describe("node-saml /", function () {
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
           audience: "http://sp.example.com",
           acceptedClockSkewMs: -1,
-          cert: signingCert,
+          idpCert,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
         };
@@ -2850,7 +2854,7 @@ describe("node-saml /", function () {
       });
 
       it("onelogin xml document with audience matching one of the audiences in an AudienceRestriction should pass", async () => {
-        const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+        const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
         const xml = `<samlp:Response xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="pfxb9beedb9-b556-2a51-a783-bfcf6e91cd9c" Version="2.0" IssueInstant="2014-05-28T00:16:08Z" Destination="{recipient}" InResponseTo="_a6fc46be84e1e3cf3c50">
   <saml:Issuer>https://app.onelogin.com/saml/metadata/371755</saml:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
   <ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
@@ -2889,7 +2893,7 @@ describe("node-saml /", function () {
           entryPoint: "https://app.onelogin.com/trust/saml2/http-post/sso/371755",
           audience: "http://sp.example.com",
           acceptedClockSkewMs: -1,
-          cert: signingCert,
+          idpCert,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
         };
@@ -2903,13 +2907,13 @@ describe("node-saml /", function () {
   });
   describe("validatePostRequest()", function () {
     const signingKey = fs.readFileSync(__dirname + "/static/key.pem", "ascii");
-    const signingCert = fs.readFileSync(__dirname + "/static/cert.pem", "ascii");
+    const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "ascii");
     let samlObj: SAML;
 
     beforeEach(function () {
       samlObj = new SAML({
         callbackUrl: "http://localhost/saml/consume",
-        cert: signingCert,
+        idpCert,
         issuer: "onesaml_login",
       });
     });
@@ -2994,7 +2998,7 @@ describe("node-saml /", function () {
     it("returns profile for valid signature with encrypted nameID", async () => {
       const samlObj = new SAML({
         callbackUrl: "http://localhost/saml/consume",
-        cert: fs.readFileSync(__dirname + "/static/cert.pem", "ascii"),
+        idpCert: fs.readFileSync(__dirname + "/static/cert.pem", "ascii"),
         decryptionPvk: fs.readFileSync(__dirname + "/static/key.pem", "ascii"),
         issuer: "onelogin_saml",
       });
@@ -3017,7 +3021,7 @@ describe("node-saml /", function () {
     it("check conflicting profile fields with data from attributes", async () => {
       const testSAMLObj = new SAML({
         callbackUrl: "http://localhost/saml/consume",
-        cert: signingCert,
+        idpCert,
         issuer: "okta",
         audience: false,
         wantAssertionsSigned: false,
@@ -3055,7 +3059,7 @@ describe("node-saml /", function () {
   it("validatePostRequest errors for encrypted nameID with wrong decryptionPvk", async () => {
     const samlObj = new SAML({
       callbackUrl: "http://localhost/saml/consume",
-      cert: fs.readFileSync(__dirname + "/static/cert.pem", "ascii"),
+      idpCert: fs.readFileSync(__dirname + "/static/cert.pem", "ascii"),
       decryptionPvk: fs.readFileSync(__dirname + "/static/acme_tools_com.key", "ascii"),
       issuer: "onesaml_login",
     });
@@ -3109,7 +3113,7 @@ describe("node-saml /", function () {
         "jF3SNJh0SmHoT62vc+cJqPxMDP6E7Q1nZxsEyaAkKr2H4dSM4SlRm0VB+bS+jXsz\n" +
         "PCiRGSm8eupuxfix05LMMreo4mC7e3Ir4JhdCsXxAMZIvbNyXcvUMA==\n" +
         "-----END CERTIFICATE-----\n",
-      cert: FAKE_CERT,
+      idpCert: FAKE_CERT,
       issuer: "onesaml_login",
     });
     const request =
@@ -3133,7 +3137,7 @@ describe("node-saml /", function () {
       beforeEach(function () {
         samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: fs.readFileSync(__dirname + "/static/acme_tools_com.cert", "ascii"),
+          idpCert: fs.readFileSync(__dirname + "/static/acme_tools_com.cert", "ascii"),
           idpIssuer: "http://localhost:20000/saml2/idp/metadata.php",
           issuer: "onesaml_login",
         });
@@ -3198,7 +3202,7 @@ describe("node-saml /", function () {
       beforeEach(function () {
         samlObj = new SAML({
           callbackUrl: "http://localhost/saml/consume",
-          cert: fs.readFileSync(__dirname + "/static/acme_tools_com.cert", "ascii"),
+          idpCert: fs.readFileSync(__dirname + "/static/acme_tools_com.cert", "ascii"),
           idpIssuer: "http://localhost:20000/saml2/idp/metadata.php",
           validateInResponseTo: ValidateInResponseTo.always,
           issuer: "onesaml_login",
@@ -3261,7 +3265,7 @@ describe("node-saml /", function () {
       });
 
       it("accepts cert without header and footer line", async function () {
-        samlObj.options.cert = fs.readFileSync(
+        samlObj.options.idpCert = fs.readFileSync(
           __dirname + "/static/acme_tools_com_without_header_and_footer.cert",
           "ascii",
         );


### PR DESCRIPTION
To increase clarity and align with `xml-crypto`, `cert` has been renamed to `idpCert` and `signingCert` has been renamed to `publicCert`. The thinking is that the name should clearly indicate that private key material should not be present in this variable and where the cert should come from.