### PR TITLE
Remove unused function arguments

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -513,11 +513,7 @@ class SAML {
     );
   }
 
-  async getAuthorizeUrlAsync(
-    RelayState: string,
-    host: string | undefined,
-    options: AuthOptions,
-  ): Promise<string> {
+  async getAuthorizeUrlAsync(RelayState: string, options: AuthOptions): Promise<string> {
     const request = await this.generateAuthorizeRequestAsync(this.options.passive, false);
     const operation = "authorize";
     const overrideParams = options ? options.additionalParams || {} : {};
@@ -531,7 +527,6 @@ class SAML {
 
   async getAuthorizeMessageAsync(
     RelayState: string,
-    host?: string,
     options?: AuthOptions,
   ): Promise<querystring.ParsedUrlQueryInput> {
     assertRequired(this.options.entryPoint, "entryPoint is required");
@@ -558,11 +553,7 @@ class SAML {
     return samlMessage;
   }
 
-  async getAuthorizeFormAsync(
-    RelayState: string,
-    host?: string,
-    options?: AuthOptions,
-  ): Promise<string> {
+  async getAuthorizeFormAsync(RelayState: string, options?: AuthOptions): Promise<string> {
     assertRequired(this.options.entryPoint, "entryPoint is required");
 
     // The quoteattr() function is used in a context, where the result will not be evaluated by javascript
@@ -595,7 +586,7 @@ class SAML {
       );
     };
 
-    const samlMessage = await this.getAuthorizeMessageAsync(RelayState, host, options);
+    const samlMessage = await this.getAuthorizeMessageAsync(RelayState, options);
 
     const formInputs = Object.keys(samlMessage)
       .map((k) => {

--- a/test/samlRequest.spec.ts
+++ b/test/samlRequest.spec.ts
@@ -414,33 +414,25 @@ describe("SAML request", function () {
     const oSAML = new SAML(config);
 
     it("getAuthorizeMessageAsync", async function () {
-      const samlMessage = await oSAML.getAuthorizeMessageAsync(
-        "http://localhost/saml/consume",
-        undefined,
-        { additionalParams: { foo: "bar" } },
-      );
+      const samlMessage = await oSAML.getAuthorizeMessageAsync("http://localhost/saml/consume", {
+        additionalParams: { foo: "bar" },
+      });
 
       assertRequired(samlMessage.SAMLRequest);
       expect(samlMessage.foo).to.equal("bar");
     });
 
     it("getAuthorizeFormAsync", async function () {
-      const formBody = await oSAML.getAuthorizeFormAsync(
-        "http://localhost/saml/consume",
-        undefined,
-        { additionalParams: { foo: "bar" } },
-      );
+      const formBody = await oSAML.getAuthorizeFormAsync("http://localhost/saml/consume", {
+        additionalParams: { foo: "bar" },
+      });
 
       expect(formBody).to.match(/<!DOCTYPE html>[^]*<input.*name="SAMLRequest"[^]*<\/html>/);
       expect(formBody).to.match(/<input.*name="foo" value="bar"/);
     });
 
     it("getAuthorizeFormAsync with empty options", async function () {
-      const formBody = await oSAML.getAuthorizeFormAsync(
-        "http://localhost/saml/consume",
-        undefined,
-        {},
-      );
+      const formBody = await oSAML.getAuthorizeFormAsync("http://localhost/saml/consume", {});
 
       expect(formBody).to.match(/<!DOCTYPE html>[^]*<input.*name="SAMLRequest"[^]*<\/html>/);
       expect(formBody).to.not.match(/<input.*name="foo" value="bar"/);

--- a/test/samlTests.spec.ts
+++ b/test/samlTests.spec.ts
@@ -245,27 +245,27 @@ describe("saml.ts", function () {
 
     describe("getAuthorizeUrl", function () {
       it("calls callback with right host", async () => {
-        const target = await saml.getAuthorizeUrlAsync("", req.headers.host, {});
+        const target = await saml.getAuthorizeUrlAsync("", {});
         expect(new URL(target).host).to.equal("exampleidp.com");
       });
 
       it("calls callback with right protocol", async () => {
-        const target = await saml.getAuthorizeUrlAsync("", req.headers.host, {});
+        const target = await saml.getAuthorizeUrlAsync("", {});
         expect(new URL(target).protocol).to.equal("https:");
       });
 
       it("calls callback with right path", async () => {
-        const target = await saml.getAuthorizeUrlAsync("", req.headers.host, {});
+        const target = await saml.getAuthorizeUrlAsync("", {});
         expect(new URL(target).pathname).to.equal("/path");
       });
 
       it("calls callback with original query string", async () => {
-        const target = await saml.getAuthorizeUrlAsync("", req.headers.host, {});
+        const target = await saml.getAuthorizeUrlAsync("", {});
         expect(new URL(target).searchParams.get("key")).to.equal("value");
       });
 
       it("calls callback with additional run-time params in query string", async () => {
-        const target = await saml.getAuthorizeUrlAsync("", req.headers.host, options);
+        const target = await saml.getAuthorizeUrlAsync("", options);
         const urlSearchParams = new URL(target).searchParams;
         expect(Array.from(urlSearchParams)).to.have.lengthOf(3);
         expect(urlSearchParams.get("key")).to.equal("value");
@@ -275,7 +275,7 @@ describe("saml.ts", function () {
 
       // NOTE: This test only tests existence of the assertion, not the correctness
       it("calls callback with saml request object", async () => {
-        const target = await saml.getAuthorizeUrlAsync("", req.headers.host, {});
+        const target = await saml.getAuthorizeUrlAsync("", {});
         expect(new URL(target).searchParams.get("SAMLRequest")).to.not.be.empty;
       });
     });

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -1576,7 +1576,7 @@ describe("node-saml /", function () {
           skipRequestCompression: true,
         };
         const samlObj = new SAML(samlConfig);
-        const authorizeUrl = await samlObj.getAuthorizeUrlAsync("", "", {});
+        const authorizeUrl = await samlObj.getAuthorizeUrlAsync("", {});
         const qry = querystring.parse(new URL(authorizeUrl).searchParams.toString() || "");
         expect(qry.SigAlg).to.equal("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256");
         expect(qry.Signature).to.equal(
@@ -1627,7 +1627,7 @@ describe("node-saml /", function () {
           skipRequestCompression: true,
         };
         const samlObj = new SAML(samlConfig);
-        const authorizeUrl = await samlObj.getAuthorizeUrlAsync("", "", {});
+        const authorizeUrl = await samlObj.getAuthorizeUrlAsync("", {});
         const qry = querystring.parse(new URL(authorizeUrl).searchParams.toString() || "");
         expect(qry.SigAlg).to.equal("http://www.w3.org/2000/09/xmldsig#rsa-sha1");
         expect(qry.Signature).to.equal(
@@ -1654,7 +1654,7 @@ describe("node-saml /", function () {
           skipRequestCompression: true,
         };
         const samlObj = new SAML(samlConfig);
-        const authorizeUrl = await samlObj.getAuthorizeUrlAsync("", "", {});
+        const authorizeUrl = await samlObj.getAuthorizeUrlAsync("", {});
         const qry = querystring.parse(new URL(authorizeUrl).searchParams.toString() || "");
         expect(qry.SigAlg).to.equal("http://www.w3.org/2000/09/xmldsig#rsa-sha1");
         expect(qry.Signature).to.equal(


### PR DESCRIPTION
As was pointed out in [this](https://github.com/node-saml/passport-saml/issues/909#issuecomment-2048493744) comment, the changes made in #214 were incomplete. This PR addresses this, but doing so is a breaking change.