### PR TITLE
feat: improve error messages when validating pems

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -51,16 +51,20 @@ const normalizePemFile = (pem: string): string => {
 /**
  * This function currently expects to get data in PEM format or in base64 format.
  */
-export const keyInfoToPem = (keyInfo: string | Buffer, pemLabel: PemLabel): string => {
+export const keyInfoToPem = (
+  keyInfo: string | Buffer,
+  pemLabel: PemLabel,
+  optionName = "keyInfo",
+): string => {
   const keyData = Buffer.isBuffer(keyInfo) ? keyInfo.toString("latin1") : keyInfo;
-  assertRequired(keyData, "keyInfo is not provided");
+  assertRequired(keyData, `${optionName} is not provided`);
 
   if (PEM_FORMAT_REGEX.test(keyData)) {
     return normalizePemFile(keyData);
   }
 
   const isBase64 = BASE64_REGEX.test(keyData);
-  assertRequired(isBase64 || undefined, "keyInfo is not in PEM format or in base64 format");
+  assertRequired(isBase64 || undefined, `${optionName} is not in PEM format or in base64 format`);
 
   const pem = `-----BEGIN ${pemLabel}-----\n${keyInfo}\n-----END ${pemLabel}-----`;
 

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -52,24 +52,22 @@ const deflateRawAsync = util.promisify(zlib.deflateRaw);
 const resolveAndParseKeyInfosToPem = async ({
   idpCert,
 }: Pick<SamlOptions, "idpCert">): Promise<string[]> => {
-  const keyInfosToHandle: string[] = [];
-  const pemFiles: string[] = [];
-  if (typeof idpCert === "function") {
-    await util
-      .promisify(idpCert as IdpCertCallback)()
-      .then((certs) => {
-        assertRequired(certs, "callback didn't return idpCert");
-        keyInfosToHandle.push(...(Array.isArray(certs) ? certs : [certs]));
-      });
-  } else {
-    keyInfosToHandle.push(...(Array.isArray(idpCert) ? idpCert : [idpCert]));
-  }
-  // Verify and normalize each PEM file.
-  keyInfosToHandle.forEach((cert, index) => {
-    pemFiles.push(keyInfoToPem(cert, "CERTIFICATE", `idpCert[${index}]`));
-  });
+  const certs =
+    typeof idpCert === "function"
+      ? await util
+          .promisify(idpCert as IdpCertCallback)()
+          .then((resolvedCerts) => {
+            assertRequired(resolvedCerts, "callback didn't return idpCert");
 
-  return pemFiles;
+            return resolvedCerts;
+          })
+      : idpCert;
+
+  if (Array.isArray(certs)) {
+    return certs.map((cert, index) => keyInfoToPem(cert, "CERTIFICATE", `idpCert[${index}]`));
+  } else {
+    return [keyInfoToPem(certs, "CERTIFICATE", `idpCert`)];
+  }
 };
 
 class SAML {

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -65,8 +65,8 @@ const resolveAndParseKeyInfosToPem = async ({
     keyInfosToHandle.push(...(Array.isArray(idpCert) ? idpCert : [idpCert]));
   }
   // Verify and normalize each PEM file.
-  keyInfosToHandle.forEach((cert) => {
-    pemFiles.push(keyInfoToPem(cert, "CERTIFICATE"));
+  keyInfosToHandle.forEach((cert, index) => {
+    pemFiles.push(keyInfoToPem(cert, "CERTIFICATE", `idpCert[${index}]`));
   });
 
   return pemFiles;
@@ -189,7 +189,7 @@ class SAML {
     }
     signer.update(querystring.stringify(samlMessageToSign));
     samlMessage.Signature = signer.sign(
-      keyInfoToPem(this.options.privateKey, "PRIVATE KEY"),
+      keyInfoToPem(this.options.privateKey, "PRIVATE KEY", "privateKey"),
       "base64",
     );
   }

--- a/test/crypto.spec.ts
+++ b/test/crypto.spec.ts
@@ -29,6 +29,12 @@ describe("crypto.ts", function () {
         expect(() => keyInfoToPem(null as never, "CERTIFICATE")).to.throw();
       });
 
+      it("should throw with null with optionName in message", function () {
+        expect(() => keyInfoToPem(null as never, "CERTIFICATE", "optionName")).to.throw(
+          /optionName/,
+        );
+      });
+
       it("should throw with false", function () {
         expect(() => keyInfoToPem(false as never, "CERTIFICATE")).to.throw();
       });
@@ -43,6 +49,12 @@ describe("crypto.ts", function () {
 
       it("should throw if string is not in PEM format or not in Base64 format", function () {
         expect(() => keyInfoToPem("I'm not pem file", "CERTIFICATE")).to.throw();
+      });
+
+      it("should throw if string is not in PEM format or not in Base64 format with optionName in message", function () {
+        expect(() => keyInfoToPem("I'm not pem file", "CERTIFICATE", "optionName")).to.throw(
+          /optionName/,
+        );
       });
 
       it("should throw if cert is missing newlines after header and before footer", function () {


### PR DESCRIPTION
As proposed in https://github.com/node-saml/node-saml/issues/361#issuecomment-2059220760 I've added better error messages to the verification of the pem files. The error message now point towards the corresponding option that's being validated. E.g. if singular `idpCert` is wrongly provided, the error will be:
> idpCert is not in PEM format or in base64 format

If there is an array, it might be:

> idpCert[1] is not in PEM format or in base64 format

I did a little refactoring to allow for the figuring the difference between singular and array passed certs.