### PR TITLE
Add CI test & lint for Node.js 22

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18, 20]
+        node-version: [18, 20, 22]
         experimental: [false]
         include:
           - os: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [18, 20, 22]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Since Node.js 22 is now active, thought we should start testing and linting against it. https://nodejs.org/en/about/previous-releases

# Checklist:

- Issue Addressed: [ ]
- Link to SAML spec: [ ]
- Tests included? [ ]
- Documentation updated? []
