### PR TITLE
Remove unused `host` parameter

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -499,7 +499,6 @@ class SAML {
 
   async getAuthorizeUrlAsync(
     RelayState: string,
-    host: string | undefined,
     options: AuthOptions,
   ): Promise<string> {
     const request = await this.generateAuthorizeRequestAsync(this.options.passive, false);
@@ -515,7 +514,6 @@ class SAML {
 
   async getAuthorizeMessageAsync(
     RelayState: string,
-    host?: string,
     options?: AuthOptions,
   ): Promise<querystring.ParsedUrlQueryInput> {
     assertRequired(this.options.entryPoint, "entryPoint is required");
@@ -542,7 +540,6 @@ class SAML {
 
   async getAuthorizeFormAsync(
     RelayState: string,
-    host?: string,
     options?: AuthOptions,
   ): Promise<string> {
     assertRequired(this.options.entryPoint, "entryPoint is required");
@@ -576,7 +573,7 @@ class SAML {
       );
     };
 
-    const samlMessage = await this.getAuthorizeMessageAsync(RelayState, host, options);
+    const samlMessage = await this.getAuthorizeMessageAsync(RelayState, options);
 
     const formInputs = Object.keys(samlMessage)
       .map((k) => {


### PR DESCRIPTION
# Description

As referenced [here](https://github.com/node-saml/passport-saml/issues/909#issuecomment-2048493744), the `host` parameter is deprecated and should have been removed in the last breaking release. This PR is queued up for when we're ready for the next breaking release (which will also remove Node@18 support).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the process for generating authorization URLs and forms by removing an unused parameter from related methods. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->