### PR TITLE
Set `inResponseTo` validation to `always`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ const saml = new SAML(options);
 
 - **InResponseTo Validation**
 - `validateInResponseTo`:
-  - if `"always"`, then InResponseTo will be validated from incoming SAML responses
-  - if `"never"`(default), then InResponseTo won't be validated.
+  - if `"always"` (default), then InResponseTo will be validated from incoming SAML responses
+  - if `"never"`, then InResponseTo won't be validated.
   - if `"ifPresent"`, then InResponseTo will only be validated if present in the incoming SAML response
 - `requestIdExpirationPeriodMs`: Defines the expiration time when a Request ID generated for a SAML request will not be valid if seen in a SAML response in the `InResponseTo` field. Default is 8 hours.
 - `cacheProvider`: Defines the implementation for a cache provider used to store request Ids generated in SAML requests as part of `InResponseTo` validation. Default is a built-in in-memory cache provider. For details see the 'Cache Provider' section.

--- a/src/saml.ts
+++ b/src/saml.ts
@@ -134,7 +134,7 @@ class SAML {
       authnContext: ctorOptions.authnContext ?? [
         "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
       ],
-      validateInResponseTo: ctorOptions.validateInResponseTo ?? ValidateInResponseTo.never,
+      validateInResponseTo: ctorOptions.validateInResponseTo ?? ValidateInResponseTo.always,
       idpCert: ctorOptions.idpCert,
       requestIdExpirationPeriodMs: ctorOptions.requestIdExpirationPeriodMs ?? 28800000, // 8 hours
       cacheProvider:

--- a/test/samlTests.spec.ts
+++ b/test/samlTests.spec.ts
@@ -5,7 +5,7 @@ import { URL } from "url";
 import { expect } from "chai";
 import * as assert from "assert";
 import { SAML } from "../src/saml";
-import { AuthOptions, IdpCertCallback } from "../src/types";
+import { AuthOptions, IdpCertCallback, ValidateInResponseTo } from "../src/types";
 import { assertRequired } from "../src/utility";
 import { FAKE_CERT, RequestWithUser, TEST_CERT_MULTILINE } from "./types";
 import { parseDomFromString, parseXml2JsFromString, validateSignature } from "../src/xml";
@@ -169,6 +169,7 @@ describe("saml.ts", function () {
         idpCert: publicKey,
         issuer: "onesaml_login",
         audience: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       });
 
       await triggerGetKeyInfosAsPemFunctionCall(samlObj);
@@ -181,6 +182,7 @@ describe("saml.ts", function () {
         idpCert: publicKey,
         issuer: "onesaml_login",
         audience: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       });
 
       await triggerGetKeyInfosAsPemFunctionCall(samlObj);
@@ -200,6 +202,7 @@ describe("saml.ts", function () {
         idpCert,
         issuer: "onesaml_login",
         audience: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       });
 
       const oldPems = samlObj.pemFiles;

--- a/test/test-signatures.spec.ts
+++ b/test/test-signatures.spec.ts
@@ -1,7 +1,7 @@
 import { SAML } from "../src";
 import * as fs from "fs";
 import * as sinon from "sinon";
-import { SamlConfig } from "../src/types";
+import { SamlConfig, ValidateInResponseTo } from "../src/types";
 import * as xml from "../src/xml";
 import * as assert from "assert";
 import { expect } from "chai";
@@ -94,25 +94,30 @@ describe("Signatures", function () {
     //== VALID
     it(
       "R1A - both signed => valid",
-      testOneResponse("/valid/response.root-signed.assertion-signed.xml", false, 2),
+      testOneResponse("/valid/response.root-signed.assertion-signed.xml", false, 2, {
+        validateInResponseTo: ValidateInResponseTo.never,
+      }),
     );
     const publicKey = fs.readFileSync(__dirname + "/static/pub.pem", "ascii");
     it(
       "R1A - both signed, verify using public key => valid",
       testOneResponse("/valid/response.root-signed.assertion-signed.xml", false, 2, {
         idpCert: publicKey,
+        validateInResponseTo: ValidateInResponseTo.never,
       }),
     );
     it(
       "R1A - root signed => valid",
       testOneResponse("/valid/response.root-signed.assertion-unsigned.xml", false, 1, {
         wantAssertionsSigned: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       }),
     );
     it(
       "R1A - assertion signed => valid",
       testOneResponse("/valid/response.root-unsigned.assertion-signed.xml", false, 2, {
         wantAuthnResponseSigned: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       }),
     );
     it(
@@ -120,6 +125,7 @@ describe("Signatures", function () {
       testOneResponse("/valid/response.root-unsigned.assertion-signed.xml", false, 2, {
         wantAuthnResponseSigned: false,
         wantAssertionsSigned: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       }),
     );
 
@@ -130,6 +136,7 @@ describe("Signatures", function () {
         "/valid/response.root-unsigned.assertion-signed.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -138,6 +145,7 @@ describe("Signatures", function () {
         "/invalid/response.root-unsigned.assertion-unsigned.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -149,6 +157,7 @@ describe("Signatures", function () {
         {
           wantAuthnResponseSigned: false,
           wantAssertionsSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         },
       ),
     );
@@ -158,6 +167,7 @@ describe("Signatures", function () {
         "/invalid/response.root-signed.assertion-signed.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -166,6 +176,7 @@ describe("Signatures", function () {
         "/invalid/response.root-signed.assertion-unsigned.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -174,11 +185,14 @@ describe("Signatures", function () {
         "/invalid/response.root-unsigned.assertion-signed.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
       "R1A - root signed - wantAssertionsSigned=true => error",
-      testOneResponse("/valid/response.root-signed.assertion-unsigned.xml", INVALID_SIGNATURE, 2),
+      testOneResponse("/valid/response.root-signed.assertion-unsigned.xml", INVALID_SIGNATURE, 2, {
+        validateInResponseTo: ValidateInResponseTo.never,
+      }),
     );
     it(
       "R1A - root signed - assertion unsigned encrypted -wantAssertionsSigned=true => error",
@@ -188,6 +202,7 @@ describe("Signatures", function () {
         2,
         {
           decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
+          validateInResponseTo: ValidateInResponseTo.never,
         },
       ),
     );
@@ -197,6 +212,7 @@ describe("Signatures", function () {
         "/invalid/response.root-signed.assertion-invalidly-signed.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -207,6 +223,7 @@ describe("Signatures", function () {
         2,
         {
           decryptionPvk: fs.readFileSync(__dirname + "/static/testshib encryption pvk.pem"),
+          validateInResponseTo: ValidateInResponseTo.never,
         },
       ),
     );
@@ -216,6 +233,7 @@ describe("Signatures", function () {
         "/invalid/response.root-signed-transforms.assertion-unsigned.xml",
         INVALID_TOO_MANY_TRANSFORMS,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -226,6 +244,7 @@ describe("Signatures", function () {
         2,
         {
           wantAuthnResponseSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         },
       ),
     );
@@ -237,6 +256,7 @@ describe("Signatures", function () {
         1,
         {
           wantAssertionsSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         },
       ),
     );
@@ -256,7 +276,9 @@ describe("Signatures", function () {
     //== VALID
     it(
       "R1A1Ad - signed root + assertion + advice => valid",
-      testOneResponse("/valid/response.root-signed.assertion-signed.1advice-signed.xml", false, 2),
+      testOneResponse("/valid/response.root-signed.assertion-signed.1advice-signed.xml", false, 2, {
+        validateInResponseTo: ValidateInResponseTo.never,
+      }),
     );
     it(
       "R1A1Ad - signed root + assertion => valid",
@@ -264,6 +286,7 @@ describe("Signatures", function () {
         "/valid/response.root-signed.assertion-signed.1advice-unsigned.xml",
         false,
         2,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -272,7 +295,7 @@ describe("Signatures", function () {
         "/valid/response.root-unsigned.assertion-signed.1advice-signed.xml",
         false,
         2,
-        { wantAuthnResponseSigned: false },
+        { wantAuthnResponseSigned: false, validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -283,6 +306,7 @@ describe("Signatures", function () {
         1,
         {
           wantAssertionsSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         },
       ),
     );
@@ -292,7 +316,7 @@ describe("Signatures", function () {
         "/valid/response.root-unsigned.assertion-signed.1advice-unsigned.xml",
         false,
         2,
-        { wantAuthnResponseSigned: false },
+        { wantAuthnResponseSigned: false, validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
 
@@ -303,6 +327,7 @@ describe("Signatures", function () {
         "/invalid/response.root-unsigned.assertion-unsigned.1advice-unsigned.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -311,6 +336,7 @@ describe("Signatures", function () {
         "/invalid/response.root-signed.assertion-signed.1advice-signed.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -319,6 +345,7 @@ describe("Signatures", function () {
         "/invalid/response.root-signed.assertion-signed.1advice-unsigned.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -327,7 +354,7 @@ describe("Signatures", function () {
         "/invalid/response.root-unsigned.assertion-signed.1advice-signed.xml",
         INVALID_SIGNATURE,
         2,
-        { wantAuthnResponseSigned: false },
+        { wantAuthnResponseSigned: false, validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -336,6 +363,7 @@ describe("Signatures", function () {
         "/invalid/response.root-signed.assertion-unsigned.1advice-unsigned.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -344,7 +372,7 @@ describe("Signatures", function () {
         "/invalid/response.root-unsigned.assertion-signed.1advice-unsigned.xml",
         INVALID_SIGNATURE,
         2,
-        { wantAuthnResponseSigned: false },
+        { wantAuthnResponseSigned: false, validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
   });
@@ -363,7 +391,9 @@ describe("Signatures", function () {
     //== VALID
     it(
       "R1A2Ad - signed root + assertion + advice => valid",
-      testOneResponse("/valid/response.root-signed.assertion-signed.2advice-signed.xml", false, 2),
+      testOneResponse("/valid/response.root-signed.assertion-signed.2advice-signed.xml", false, 2, {
+        validateInResponseTo: ValidateInResponseTo.never,
+      }),
     );
     it(
       "R1A2Ad - signed root + assertion => valid",
@@ -371,6 +401,7 @@ describe("Signatures", function () {
         "/valid/response.root-signed.assertion-signed.2advice-unsigned.xml",
         false,
         2,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -379,7 +410,7 @@ describe("Signatures", function () {
         "/valid/response.root-signed.assertion-unsigned.2advice-unsigned.xml",
         false,
         1,
-        { wantAssertionsSigned: false },
+        { wantAssertionsSigned: false, validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
 
@@ -390,6 +421,7 @@ describe("Signatures", function () {
         "/invalid/response.root-unsigned.assertion-unsigned.2advice-unsigned.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -398,6 +430,7 @@ describe("Signatures", function () {
         "/invalid/response.root-signed.assertion-signed.2advice-signed.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -406,6 +439,7 @@ describe("Signatures", function () {
         "/invalid/response.root-signed.assertion-signed.2advice-unsigned.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
     it(
@@ -414,6 +448,7 @@ describe("Signatures", function () {
         "/invalid/response.root-signed.assertion-unsigned.2advice-unsigned.xml",
         INVALID_DOCUMENT_SIGNATURE,
         1,
+        { validateInResponseTo: ValidateInResponseTo.never },
       ),
     );
   });
@@ -438,12 +473,16 @@ describe("Signatures", function () {
 
     it("CRLF line endings", async () => {
       const body = makeBody(samlResponseXml.replace(/\n/g, "\r\n"));
-      await testOneResponseBody(body, false, 2);
+      await testOneResponseBody(body, false, 2, {
+        validateInResponseTo: ValidateInResponseTo.never,
+      });
     });
 
     it("CR line endings", async () => {
       const body = makeBody(samlResponseXml.replace(/\n/g, "\r"));
-      await testOneResponseBody(body, false, 2);
+      await testOneResponseBody(body, false, 2, {
+        validateInResponseTo: ValidateInResponseTo.never,
+      });
     });
   });
 
@@ -462,6 +501,7 @@ describe("Signatures", function () {
       "Attribute with &#13;",
       testOneResponse("/valid/response.root-signed.assertion-unsigned-13.xml", false, 1, {
         wantAssertionsSigned: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       }),
     );
 
@@ -469,6 +509,7 @@ describe("Signatures", function () {
       "Attribute with &#xd;",
       testOneResponse("/valid/response.root-signed.assertion-unsigned-xd.xml", false, 1, {
         wantAssertionsSigned: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       }),
     );
   });
@@ -488,6 +529,7 @@ describe("Signatures", function () {
       "Signature attributes with &#13;",
       testOneResponse("/valid/response.root-signed.assertion-unsigned-13-signature.xml", false, 1, {
         wantAssertionsSigned: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       }),
     );
 
@@ -495,6 +537,7 @@ describe("Signatures", function () {
       "Signature attributes with &#xd;",
       testOneResponse("/valid/response.root-signed.assertion-unsigned-xd-signature.xml", false, 1, {
         wantAssertionsSigned: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       }),
     );
   });

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -3002,6 +3002,7 @@ describe("node-saml /", function () {
         idpCert: fs.readFileSync(__dirname + "/static/cert.pem", "ascii"),
         decryptionPvk: fs.readFileSync(__dirname + "/static/key.pem", "ascii"),
         issuer: "onelogin_saml",
+        validateInResponseTo: ValidateInResponseTo.never,
       });
       const body = {
         SAMLRequest: fs.readFileSync(
@@ -3026,6 +3027,7 @@ describe("node-saml /", function () {
         issuer: "okta",
         audience: false,
         wantAssertionsSigned: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       });
       const xml =
         '<Response xmlns="urn:oasis:names:tc:SAML:2.0:protocol" ID="response0">' +

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -757,6 +757,7 @@ describe("node-saml /", function () {
           idpCert: `-----BEGIN CERTIFICATE-----\n${TEST_CERT}\n-----END CERTIFICATE-----`,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         });
         await assert.rejects(samlObj.validatePostResponseAsync(container), {
           message: /Responder.*Required NameID format not supported/,
@@ -773,6 +774,7 @@ describe("node-saml /", function () {
           idpCert: FAKE_CERT,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         });
         await assert.rejects(samlObj.validatePostResponseAsync(container), {
           message: /Responder.*InvalidNameIDPolicy/,
@@ -789,6 +791,7 @@ describe("node-saml /", function () {
           idpCert: FAKE_CERT,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         });
         await assert.rejects(samlObj.validatePostResponseAsync(container), {
           message: "Invalid signature: NoPassive",
@@ -811,6 +814,7 @@ describe("node-saml /", function () {
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
           wantAuthnResponseSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         });
         const response = await samlObj.validatePostResponseAsync(container);
         expect(response).to.deep.equal({ profile: null, loggedOut: false });
@@ -833,6 +837,7 @@ describe("node-saml /", function () {
           audience: false,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         });
         const { profile } = await samlObj.validatePostResponseAsync(container);
         assertRequired(profile, "profile must exist");
@@ -1069,6 +1074,7 @@ describe("node-saml /", function () {
           audience: false,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         };
         const noAudienceSamlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
@@ -1076,6 +1082,7 @@ describe("node-saml /", function () {
           idpCert: TEST_CERT,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         };
         const noCertSamlConfig: SamlConfig = {
           callbackUrl: "http://localhost/saml/consume",
@@ -1326,6 +1333,7 @@ describe("node-saml /", function () {
             audience: false,
             issuer: "onesaml_login",
             wantAuthnResponseSigned: false,
+            validateInResponseTo: ValidateInResponseTo.never,
           };
           const xml =
             '<samlp:Response xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="R689b0733bccca22a137e3654830312332940b1be" Version="2.0" IssueInstant="2014-05-28T00:16:08Z" Destination="{recipient}" InResponseTo="_a6fc46be84e1e3cf3c50"><saml:Issuer>https://app.onelogin.com/saml/metadata/371755</saml:Issuer><samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>' +
@@ -1351,6 +1359,7 @@ describe("node-saml /", function () {
             audience: false,
             issuer: "onesaml_login",
             wantAuthnResponseSigned: false,
+            validateInResponseTo: ValidateInResponseTo.never,
           };
           const xml =
             '<samlp:Response xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="R689b0733bccca22a137e3654830312332940b1be" Version="2.0" IssueInstant="2014-05-28T00:16:08Z" Destination="{recipient}" InResponseTo="_a6fc46be84e1e3cf3c50"><saml:Issuer>https://app.onelogin.com/saml/metadata/371755</saml:Issuer><samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>' +
@@ -1376,6 +1385,7 @@ describe("node-saml /", function () {
             audience: false,
             issuer: "onesaml_login",
             wantAuthnResponseSigned: false,
+            validateInResponseTo: ValidateInResponseTo.never,
           };
           const xml =
             '<samlp:Response xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="R689b0733bccca22a137e3654830312332940b1be" Version="2.0" IssueInstant="2014-05-28T00:16:08Z" Destination="{recipient}" InResponseTo="_a6fc46be84e1e3cf3c50"><saml:Issuer>https://app.onelogin.com/saml/metadata/371755</saml:Issuer><samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>' +
@@ -1400,6 +1410,7 @@ describe("node-saml /", function () {
               callback(errorToReturn);
             },
             issuer: "onesaml_login",
+            validateInResponseTo: ValidateInResponseTo.never,
           };
           const xml =
             '<samlp:Response xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="R689b0733bccca22a137e3654830312332940b1be" Version="2.0" IssueInstant="2014-05-28T00:16:08Z" Destination="{recipient}" InResponseTo="_a6fc46be84e1e3cf3c50"><saml:Issuer>https://app.onelogin.com/saml/metadata/371755</saml:Issuer><samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>' +
@@ -1460,6 +1471,7 @@ describe("node-saml /", function () {
             audience: false,
             issuer: "onesaml_login",
             wantAssertionsSigned: false,
+            validateInResponseTo: ValidateInResponseTo.never,
           });
           const { profile } = await samlObj.validatePostResponseAsync(container);
           assertRequired(profile, "profile must exist");
@@ -1503,6 +1515,7 @@ describe("node-saml /", function () {
             idpCert: TEST_CERT,
             issuer: "onesaml_login",
             wantAuthnResponseSigned: false,
+            validateInResponseTo: ValidateInResponseTo.never,
           });
           await assert.rejects(samlObj.validatePostResponseAsync(container), {
             message: "Invalid signature",
@@ -1539,6 +1552,7 @@ describe("node-saml /", function () {
             audience: false,
             issuer: "onesaml_login",
             wantAssertionsSigned: false,
+            validateInResponseTo: ValidateInResponseTo.never,
           });
           const { profile } = await samlObj.validatePostResponseAsync(container);
           assertRequired(profile, "profile must exist");
@@ -2424,6 +2438,7 @@ describe("node-saml /", function () {
         issuer: "onesaml_login",
         wantAssertionsSigned: false,
         wantAuthnResponseSigned: false,
+        validateInResponseTo: ValidateInResponseTo.never,
       };
       let fakeClock: sinon.SinonFakeTimers;
 
@@ -2575,6 +2590,7 @@ describe("node-saml /", function () {
           audience: false,
           issuer: "onesaml_login",
           wantAuthnResponseSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         };
         const samlObj = new SAML(samlConfig);
 
@@ -2747,6 +2763,7 @@ describe("node-saml /", function () {
           idpCert,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         };
         const samlObj = new SAML(samlConfig);
         await assert.rejects(samlObj.validatePostResponseAsync(container), {
@@ -2796,6 +2813,7 @@ describe("node-saml /", function () {
           idpCert,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         };
         const samlObj = new SAML(samlConfig);
         await assert.rejects(samlObj.validatePostResponseAsync(container), {
@@ -2846,6 +2864,7 @@ describe("node-saml /", function () {
           idpCert,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         };
         const samlObj = new SAML(samlConfig);
 
@@ -2897,6 +2916,7 @@ describe("node-saml /", function () {
           idpCert,
           issuer: "onesaml_login",
           wantAssertionsSigned: false,
+          validateInResponseTo: ValidateInResponseTo.never,
         };
         const samlObj = new SAML(samlConfig);
 


### PR DESCRIPTION
# Description

This tightens `inResponseTo` validation to `always` based on [this](https://github.com/node-saml/node-saml/pull/314#issuecomment-1684289377) comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation to reflect the new default behavior for the `validateInResponseTo` setting.

* **Bug Fixes**
  * Adjusted tests to explicitly disable `InResponseTo` validation where necessary, ensuring consistent test results.

* **Refactor**
  * Changed the default behavior to always validate the `InResponseTo` attribute in SAML responses unless specified otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->