### PR TITLE
Update to support Node strip-only TypeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prerelease": "git clean -xfd && npm ci && npm run lint && npm test && npm run build",
     "release": "release-it",
     "test": "npm run build && nyc mocha --config .mocharc.json",
-    "test-watch": "mocha --watch",
+    "test-watch": "mocha --config .mocharc.json --watch",
     "tsc": "tsc",
     "tsc-watch": "tsc --watch",
     "update": "npx npm-check-updates -du",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier-watch": "npm run prettier-format && onchange -k -p 100 \".\" -- prettier --config .prettierrc.json --write {{file}}",
     "prerelease": "git clean -xfd && npm ci && npm run lint && npm test && npm run build",
     "release": "release-it",
-    "test": "npm run tsc && nyc mocha",
+    "test": "npm run build && nyc mocha --config .mocharc.json",
     "test-watch": "mocha --watch",
     "tsc": "tsc",
     "tsc-watch": "tsc --watch",

--- a/test/samlRequest.spec.ts
+++ b/test/samlRequest.spec.ts
@@ -98,7 +98,7 @@ describe("SAML request", function () {
           const decoded = Buffer.from(encodedSamlRequest, "base64");
           const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(inflated.toString());
+          return parseStringPromise(inflated.toString("utf8"));
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -121,7 +121,7 @@ describe("SAML request", function () {
           const decoded = Buffer.from(encodedSamlRequest, "base64");
           const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(inflated.toString());
+          return parseStringPromise(inflated.toString("utf8"));
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -186,7 +186,7 @@ describe("SAML request", function () {
           const decoded = Buffer.from(encodedSamlRequest, "base64");
           const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(inflated.toString());
+          return parseStringPromise(inflated.toString("utf8"));
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -209,7 +209,7 @@ describe("SAML request", function () {
           const decoded = Buffer.from(encodedSamlRequest, "base64");
           const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(inflated.toString());
+          return parseStringPromise(inflated.toString("utf8"));
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -278,7 +278,7 @@ describe("SAML request", function () {
           const decoded = Buffer.from(encodedSamlRequest, "base64");
           const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(inflated.toString());
+          return parseStringPromise(inflated.toString("utf8"));
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -301,7 +301,7 @@ describe("SAML request", function () {
           const decoded = Buffer.from(encodedSamlRequest, "base64");
           const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(inflated.toString());
+          return parseStringPromise(inflated.toString("utf8"));
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -370,7 +370,7 @@ describe("SAML request", function () {
           const decoded = Buffer.from(encodedSamlRequest, "base64");
           const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(inflated.toString());
+          return parseStringPromise(inflated.toString("utf8"));
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -393,7 +393,7 @@ describe("SAML request", function () {
           const decoded = Buffer.from(encodedSamlRequest, "base64");
           const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(inflated.toString());
+          return parseStringPromise(inflated.toString("utf8"));
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -491,7 +491,7 @@ describe("SAML request", function () {
           const encodedSamlRequest = samlMessage.SAMLRequest as string;
           const buffer = Buffer.from(encodedSamlRequest, "base64");
 
-          return parseStringPromise(buffer.toString());
+          return parseStringPromise(buffer.toString("utf8"));
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -512,7 +512,7 @@ describe("SAML request", function () {
           const encodedSamlRequest = samlRequestMatchValues?.[1];
           const buffer = Buffer.from(encodedSamlRequest, "base64");
 
-          return parseStringPromise(buffer.toString());
+          return parseStringPromise(buffer.toString("utf8"));
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];

--- a/test/samlRequest.spec.ts
+++ b/test/samlRequest.spec.ts
@@ -95,10 +95,10 @@ describe("SAML request", function () {
           assertRequired(samlMessage.SAMLRequest);
           const encodedSamlRequest = samlMessage.SAMLRequest as string;
 
-          let buffer = Buffer.from(encodedSamlRequest, "base64");
-          buffer = zlib.inflateRawSync(buffer);
+          const decoded = Buffer.from(encodedSamlRequest, "base64");
+          const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(buffer.toString());
+          return parseStringPromise(inflated.toString());
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -118,10 +118,10 @@ describe("SAML request", function () {
           assertRequired(samlRequestMatchValues?.[1]);
           const encodedSamlRequest = samlRequestMatchValues?.[1];
 
-          let buffer = Buffer.from(encodedSamlRequest, "base64");
-          buffer = zlib.inflateRawSync(buffer);
+          const decoded = Buffer.from(encodedSamlRequest, "base64");
+          const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(buffer.toString());
+          return parseStringPromise(inflated.toString());
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -183,10 +183,10 @@ describe("SAML request", function () {
           assertRequired(samlMessage.SAMLRequest);
           const encodedSamlRequest = samlMessage.SAMLRequest as string;
 
-          let buffer = Buffer.from(encodedSamlRequest, "base64");
-          buffer = zlib.inflateRawSync(buffer);
+          const decoded = Buffer.from(encodedSamlRequest, "base64");
+          const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(buffer.toString());
+          return parseStringPromise(inflated.toString());
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -206,10 +206,10 @@ describe("SAML request", function () {
           assertRequired(samlRequestMatchValues?.[1]);
           const encodedSamlRequest = samlRequestMatchValues?.[1];
 
-          let buffer = Buffer.from(encodedSamlRequest, "base64");
-          buffer = zlib.inflateRawSync(buffer);
+          const decoded = Buffer.from(encodedSamlRequest, "base64");
+          const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(buffer.toString());
+          return parseStringPromise(inflated.toString());
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -275,10 +275,10 @@ describe("SAML request", function () {
           assertRequired(samlMessage.SAMLRequest);
           const encodedSamlRequest = samlMessage.SAMLRequest as string;
 
-          let buffer = Buffer.from(encodedSamlRequest, "base64");
-          buffer = zlib.inflateRawSync(buffer);
+          const decoded = Buffer.from(encodedSamlRequest, "base64");
+          const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(buffer.toString());
+          return parseStringPromise(inflated.toString());
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -298,10 +298,10 @@ describe("SAML request", function () {
           assertRequired(samlRequestMatchValues?.[1]);
           const encodedSamlRequest = samlRequestMatchValues?.[1];
 
-          let buffer = Buffer.from(encodedSamlRequest, "base64");
-          buffer = zlib.inflateRawSync(buffer);
+          const decoded = Buffer.from(encodedSamlRequest, "base64");
+          const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(buffer.toString());
+          return parseStringPromise(inflated.toString());
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -367,10 +367,10 @@ describe("SAML request", function () {
           assertRequired(samlMessage.SAMLRequest);
           const encodedSamlRequest = samlMessage.SAMLRequest as string;
 
-          let buffer = Buffer.from(encodedSamlRequest, "base64");
-          buffer = zlib.inflateRawSync(buffer);
+          const decoded = Buffer.from(encodedSamlRequest, "base64");
+          const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(buffer.toString());
+          return parseStringPromise(inflated.toString());
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];
@@ -390,10 +390,10 @@ describe("SAML request", function () {
           assertRequired(samlRequestMatchValues?.[1]);
           const encodedSamlRequest = samlRequestMatchValues?.[1];
 
-          let buffer = Buffer.from(encodedSamlRequest, "base64");
-          buffer = zlib.inflateRawSync(buffer);
+          const decoded = Buffer.from(encodedSamlRequest, "base64");
+          const inflated = zlib.inflateRawSync(decoded);
 
-          return parseStringPromise(buffer.toString());
+          return parseStringPromise(inflated.toString());
         })
         .then((doc) => {
           delete doc["samlp:AuthnRequest"]["$"]["ID"];


### PR DESCRIPTION
# Description

Due to changes in Node, TypeScript support is now built-in and enabled by default, but only the "strip-only" version. This caused problems for our tests. This adjusts the tests to work with the newer versions of Node.

See https://github.com/nodejs/node/releases/tag/v23.6.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test commands to build the project before running tests and to use a dedicated test configuration for more reliable, consistent test runs.

* **Tests**
  * Refactored decoding and inflation steps across multiple test cases to use clearer, immutable variables and explicit UTF‑8 decoding, improving readability and maintainability with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->