### PR TITLE
feat: add support for Content Security Policy in HTTP-POST form

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -591,7 +591,7 @@ class SAML {
       '<meta charset="utf-8">',
       '<meta http-equiv="x-ua-compatible" content="ie=edge">',
       "</head>",
-      '<body onload="document.forms[0].submit()">',
+      '<body>',
       "<noscript>",
       "<p><strong>Note:</strong> Since your browser does not support JavaScript, you must press the button below once to proceed.</p>",
       "</noscript>",
@@ -599,7 +599,7 @@ class SAML {
       formInputs,
       '<input type="submit" value="Submit" />',
       "</form>",
-      '<script>document.forms[0].style.display="none";</script>', // Hide the form if JavaScript is enabled
+      '<script>document.forms[0].style.display="none"; document.forms[0].submit();</script>', // Hide and submit the form if JavaScript is enabled
       "</body>",
       "</html>",
     ].join("\r\n");


### PR DESCRIPTION
# Description

The current implementation which auto submits the form used for HTTP-POST uses the onload event. This implementation is not compatible with Content Security Policy directive script-src when not allowing unsafe-inline and/or unsafe-hashes. In order to fix this the code has been moved to the <script> tag which can be allowed in the CSP scriptSrc directive with the hash value 'sha256-iemLO/ZfqAMV0fxKLiXBGQ8M/sgpJNf0HbkRNx5GHAc='.

# Checklist:

- Issue Addressed: [x]
- Link to SAML spec: [ ]
- Tests included? [ ]
- Documentation updated? [ ]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing feature changes; behavior remains seamless.
- Bug Fixes
  - Improves consistency and reliability of automatic SSO form submission across browsers and network conditions.
- Refactor
  - Migrates auto-submission from inline page-load handlers to a dedicated script, hiding the intermediary form and triggering submission programmatically. Enhances maintainability and compatibility with stricter security policies (e.g., CSP).
- Notes
  - No changes to public APIs or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->