### PR TITLE
fix: keep empty and valueless SAML attributes in profile.attributes

### DIFF
--- a/src/saml.ts
+++ b/src/saml.ts
@@ -1167,19 +1167,35 @@ class SAML {
         const hasChildren = Object.keys(value).some((cur) => {
           return cur !== "_" && cur !== "$";
         });
-        return hasChildren ? value : value._;
+        if (hasChildren) {
+          return value;
+        }
+        // An attribute that exists but holds an empty value (for example
+        // `<AttributeValue/>` for an `xs:string`) has no character data, so
+        // xml2js leaves `_` undefined. SAML Core section 1246 says such a value
+        // is the empty string, so represent it as "" rather than dropping it.
+        return value._ ?? "";
       };
 
       if (attributes.length > 0) {
         const profileAttributes: Record<string, XMLValue | XMLValue[]> = {};
 
         attributes.forEach((attribute) => {
+          const name: string = attribute.$.Name;
+
+          // An attribute may exist with no `AttributeValue` child at all (for
+          // example `<Attribute Name="x"/>`). SAML Core section 1219 allows
+          // this for an attribute that exists but has no values. Represent it as
+          // null so consumers can tell it apart from a missing attribute,
+          // instead of dropping it from the profile entirely.
           if (!Object.prototype.hasOwnProperty.call(attribute, "AttributeValue")) {
-            // if attributes has no AttributeValue child, continue
+            profileAttributes[name] = null;
+            if (!Object.prototype.hasOwnProperty.call(profile, name)) {
+              profile[name] = null;
+            }
             return;
           }
 
-          const name: string = attribute.$.Name;
           const value: XMLValue | XMLValue[] =
             attribute.AttributeValue.length === 1
               ? attrValueMapper(attribute.AttributeValue[0])

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -839,8 +839,12 @@ describe("node-saml /", function () {
         expect(profile.issuer).to.equal("https://evil-corp.com");
         expect(profile.nameID).to.equal("vincent.vega@evil-corp.com");
         expect(profile).to.have.property("evil-corp.egroupid", "vincent.vega@evil-corp.com");
-        // attributes without attributeValue child should be ignored
-        expect(profile).to.not.have.property("evilcorp.roles");
+        // An attribute that exists but carries no AttributeValue child is kept
+        // with a null value rather than dropped, so callers can distinguish a
+        // valueless attribute from one the IdP never sent.
+        expect(profile).to.have.property("evilcorp.roles", null);
+        const attributes = profile.attributes as Record<string, unknown>;
+        expect(attributes).to.have.property("evilcorp.roles", null);
       });
 
       it("valid xml document with multiple SubjectConfirmation should validate", async () => {
@@ -1509,7 +1513,7 @@ describe("node-saml /", function () {
           });
         });
 
-        it("An undefined value given with an object should still be undefined", async () => {
+        it("An empty AttributeValue should be an empty string", async () => {
           const xml =
             '<Response xmlns="urn:oasis:names:tc:SAML:2.0:protocol" ID="response0">' +
             '<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0">' +
@@ -1542,7 +1546,42 @@ describe("node-saml /", function () {
           });
           const { profile } = await samlObj.validatePostResponseAsync(container);
           assertRequired(profile, "profile must exist");
-          expect(profile["attributeName"]).to.be.undefined;
+          const attributes = profile.attributes as Record<string, unknown>;
+          expect(attributes.attributeName).to.equal("");
+        });
+
+        it("An attribute with no AttributeValue should be null", async () => {
+          const xml =
+            '<Response xmlns="urn:oasis:names:tc:SAML:2.0:protocol" ID="response0">' +
+            '<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0">' +
+            "<saml2:AttributeStatement>" +
+            '<saml2:Attribute Name="attributeName" ' +
+            'NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified" />' +
+            "</saml2:AttributeStatement>" +
+            "</saml2:Assertion>" +
+            "</Response>";
+
+          const signingKey = fs.readFileSync(__dirname + "/static/key.pem");
+          const idpCert = fs.readFileSync(__dirname + "/static/cert.pem", "utf-8");
+          const signedXml = signXmlResponse(xml, {
+            privateKey: signingKey,
+            signatureAlgorithm: "sha1",
+          });
+
+          const base64xml = Buffer.from(signedXml).toString("base64");
+          const container = { SAMLResponse: base64xml };
+          const samlObj = new SAML({
+            callbackUrl: "http://localhost/saml/consume",
+            idpCert,
+            audience: false,
+            issuer: "onesaml_login",
+            wantAssertionsSigned: false,
+          });
+          const { profile } = await samlObj.validatePostResponseAsync(container);
+          assertRequired(profile, "profile must exist");
+          const attributes = profile.attributes as Record<string, unknown>;
+          expect(attributes).to.have.property("attributeName");
+          expect(attributes.attributeName).to.be.null;
         });
       });
     });


### PR DESCRIPTION
Fixes #227

## Problem

When a SAML assertion carries an attribute that exists but has no real value, node-saml currently loses that information in `profile.attributes`:

- An attribute with no `AttributeValue` child at all, for example `<saml2:Attribute Name="employee_id"/>`, is dropped from `profile.attributes` entirely. Google Workspace emits these in the wild.
- An attribute whose `AttributeValue` is present but empty, for example `<AttributeValue/>` with `xsi:type="xs:string"`, comes back as `undefined`.

In both cases a consumer cannot tell a valueless attribute apart from one the IdP never sent: `{}` and `{ employee_id: null }` should not collapse to the same thing.

The SAML 2.0 Core spec is explicit about both shapes:

- Section 1219: within an `<AttributeStatement>`, if the SAML attribute exists but has no values, the `<AttributeValue>` element MUST be omitted. The attribute itself still exists.
- Section 1246: if a SAML attribute includes an empty value such as the empty string, the corresponding `<AttributeValue>` element MUST be empty (serialized as `<AttributeValue/>`).

## Fix

`src/saml.ts` attribute extraction now keeps these attributes instead of discarding them:

- No `AttributeValue` child is represented as `null` (the attribute exists, no value).
- An empty `AttributeValue` is represented as the empty string `""` rather than `undefined`, matching the `xs:string` empty-value semantics from section 1246.

Populated single-value, object-valued (nested `NameID`), and multi-valued attributes are parsed exactly as before. The single-value-versus-array branch is untouched.

## Before / after

For `<saml2:Attribute Name="employee_id"/>`:

- before: `profile.attributes` does not contain `employee_id`
- after: `profile.attributes.employee_id === null`

For `<saml2:Attribute Name="x"><AttributeValue/></saml2:Attribute>`:

- before: `profile.attributes.x === undefined`
- after: `profile.attributes.x === ""`

## Tests

Added two tests under the `validatePostResponse xml signature checks` suite, including the exact null-attribute case from the issue:

- "An attribute with no AttributeValue should be null"
- "An empty AttributeValue should be an empty string"

Both fail on `master` (the first throws `expected {} to have property 'attributeName'`, the second `expected undefined to equal ''`) and pass with this change. I also updated the two existing tests that asserted the old drop/undefined behavior, since the issue calls that behavior out as incorrect:

- `accept response with an attributeStatement element without attributeValue` now expects `evilcorp.roles` to be present as `null`.
- the former `An undefined value given with an object should still be undefined` is renamed to `An empty AttributeValue should be an empty string` and asserts `""`.

Full suite is green (273 passing), and lint and prettier pass on the changed files.

## Compatibility note

This is a behavior change for consumers that relied on valueless attributes being absent or `undefined`, so it fits a semver-major release. That lines up with the breaking-change release discussed in the issue thread.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SAML attribute handling to properly preserve missing attributes with `null` values instead of omitting them.
  * Fixed attribute value mapping to correctly return empty strings for empty `AttributeValue` nodes.

* **Tests**
  * Updated test cases to validate new SAML attribute processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->