### PR TITLE
fix: Upgrade @xmldom/xmldom to 0.9.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/xml-encryption": "^1.2.4",
         "@types/xml2js": "^0.4.14",
         "@xmldom/is-dom-node": "^1.0.1",
-        "@xmldom/xmldom": "^0.8.10",
+        "@xmldom/xmldom": "^0.9.10",
         "xml-crypto": "^6.1.2",
         "xml-encryption": "^3.1.0",
         "xml2js": "^0.6.2",
@@ -1927,11 +1927,12 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/acorn": {
@@ -8558,6 +8559,15 @@
         "node": ">=16"
       }
     },
+    "node_modules/xml-crypto/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/xml-crypto/node_modules/xpath": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
@@ -8575,6 +8585,15 @@
         "@xmldom/xmldom": "^0.8.5",
         "escape-html": "^1.0.3",
         "xpath": "0.0.32"
+      }
+    },
+    "node_modules/xml-encryption/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/xml-encryption/node_modules/xpath": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/xml-encryption": "^1.2.4",
     "@types/xml2js": "^0.4.14",
     "@xmldom/is-dom-node": "^1.0.1",
-    "@xmldom/xmldom": "^0.8.10",
+    "@xmldom/xmldom": "^0.9.10",
     "xml-crypto": "^6.1.2",
     "xml-encryption": "^3.1.0",
     "xml2js": "^0.6.2",

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -280,29 +280,61 @@ export const signXml = (
   return sig.getSignedXml();
 };
 
+const samlNamespaces: Readonly<Record<string, string>> = {
+  saml: "urn:oasis:names:tc:SAML:2.0:assertion",
+  samlp: "urn:oasis:names:tc:SAML:2.0:protocol",
+  saml2: "urn:oasis:names:tc:SAML:2.0:assertion",
+  saml2p: "urn:oasis:names:tc:SAML:2.0:protocol",
+  ds: "http://www.w3.org/2000/09/xmldsig#",
+  xenc: "http://www.w3.org/2001/04/xmlenc#",
+  xs: "http://www.w3.org/2001/XMLSchema",
+  xsi: "http://www.w3.org/2001/XMLSchema-instance",
+};
+
+const formatXmlError = (
+  level: string,
+  msg: string,
+  locator?: { lineNumber?: number; columnNumber?: number } | null,
+): Error => {
+  if (msg === "missing root element") {
+    return new Error("Not a valid XML document");
+  }
+  if (locator?.lineNumber != null) {
+    return new Error(
+      `[xmldom ${level}]\t${msg}\n@#[line:${locator.lineNumber},col:${locator.columnNumber}]`,
+    );
+  }
+  return new Error(msg);
+};
+
 export const parseDomFromString = (xml: string): Promise<Document> => {
   return new Promise(function (resolve, reject) {
-    function errHandler(msg: string) {
-      return reject(new Error(msg));
+    let parseError: Error | undefined;
+    let dom: xmldom.Document;
+    try {
+      dom = new xmldom.DOMParser({
+        locator: true,
+        xmlns: samlNamespaces,
+        onError: (level, msg, context) => {
+          if (level === "error" || level === "fatalError") {
+            parseError ??= formatXmlError(level, msg, context?.locator);
+          }
+        },
+      }).parseFromString(xml, "text/xml");
+    } catch (err: unknown) {
+      if (parseError) {
+        return reject(parseError);
+      }
+      const locator = (err as { locator?: { lineNumber?: number; columnNumber?: number } })?.locator;
+      const msg = err instanceof Error ? err.message : String(err);
+      return reject(formatXmlError("error", `element parse error: Error: ${msg}`, locator));
     }
 
-    const dom = new xmldom.DOMParser({
-      /**
-       * locator is always need for error position info
-       */
-      locator: {},
-      /**
-       * you can override the errorHandler for xml parser
-       * @link http://www.saxproject.org/apidoc/org/xml/sax/ErrorHandler.html
-       */
-      errorHandler: { error: errHandler, fatalError: errHandler },
-    }).parseFromString(xml, "text/xml");
-
-    if (!Object.prototype.hasOwnProperty.call(dom, "documentElement")) {
-      return reject(new Error("Not a valid XML document"));
+    if (parseError) {
+      return reject(parseError);
     }
 
-    return resolve(dom);
+    return resolve(dom as unknown as Document);
   });
 };
 

--- a/test/test-signatures.spec.ts
+++ b/test/test-signatures.spec.ts
@@ -14,7 +14,7 @@ describe("Signatures", function () {
   const INVALID_ENCRYPTED_SIGNATURE = "Invalid signature from encrypted assertion";
   const INVALID_TOO_MANY_TRANSFORMS = "Invalid signature, too many transforms";
   const XMLDOM_ERROR =
-    "[xmldom error]\telement parse error: Error: Hierarchy request error: Only one element can be added and only after doctype\n@#[line:57,col:1]";
+    "[xmldom error]\telement parse error: Error: HierarchyRequestError: Only one element can be added and only after doctype\n@#[line:57,col:1]";
 
   const createBody = (pathToXml: string) => ({
     SAMLResponse: fs.readFileSync(__dirname + "/static/signatures" + pathToXml, "base64"),

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -3030,7 +3030,7 @@ describe("node-saml /", function () {
       const xml =
         '<Response xmlns="urn:oasis:names:tc:SAML:2.0:protocol" ID="response0">' +
         '<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0">' +
-        "<saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>" +
+        "<saml2:Issuer>http://idp.example.com/metadata.php</saml2:Issuer>" +
         "<saml2:AttributeStatement>" +
         '<saml2:Attribute Name="attributeName" ' +
         'NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">' +
@@ -3039,7 +3039,7 @@ describe("node-saml /", function () {
         'xsi:type="xs:string"/>' +
         "</saml2:Attribute>" +
         '<saml2:Attribute Name="issuer" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">' +
-        '<saml2:AttributeValue xsi:type="xs:string">test</saml2:AttributeValue>' +
+        '<saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">test</saml2:AttributeValue>' +
         "</saml2:Attribute>" +
         "</saml2:AttributeStatement>" +
         "</saml2:Assertion>" +


### PR DESCRIPTION
## Summary

- Upgrades `@xmldom/xmldom` from `^0.8.10` to `^0.9.10` to address flagged CVE's and bugs https://security.snyk.io/package/npm/%40xmldom%2Fxmldom/0.8.10
- Adapts `parseDomFromString` to the new 0.9.x `DOMParser` API (`onError` callback replacing `errorHandler`, `xmlns` option replacing implicit namespace handling, `locator: true` replacing `locator: {}`)
- Updates test expectations to match minor error message wording changes in xmldom 0.9 (`HierarchyRequestError` vs `Hierarchy request error`)
- Fixes a test that relied on undeclared namespace prefixes now that xmldom 0.9 is stricter about namespace resolution

## Test plan

- [ ] `npm test` passes with the updated dependency
- [ ] Verify no regressions in SAML response parsing with real-world payloads
- [ ] Confirm xml-crypto and xml-encryption continue to work correctly (they pin their own xmldom 0.8.x internally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML parser error reporting with detailed line and column information for easier troubleshooting.
  * Fixed XML namespace handling for SAML assertions to ensure attributes are correctly interpreted and validated.

* **Chores**
  * Updated XML processing dependency to version 0.9.10 for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->